### PR TITLE
방을 생성하고 접속하는 API 작성 및 접속 로직 수정

### DIFF
--- a/backend/src/cam/cam.controller.spec.ts
+++ b/backend/src/cam/cam.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CamController } from './cam.controller';
+
+describe('CamController', () => {
+  let controller: CamController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [CamController],
+    }).compile();
+
+    controller = module.get<CamController>(CamController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/backend/src/cam/cam.controller.spec.ts
+++ b/backend/src/cam/cam.controller.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { CamController } from './cam.controller';
+import { CamService } from './cam.service';
 
 describe('CamController', () => {
   let controller: CamController;
@@ -7,6 +8,7 @@ describe('CamController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [CamController],
+      providers: [CamService],
     }).compile();
 
     controller = module.get<CamController>(CamController);

--- a/backend/src/cam/cam.controller.ts
+++ b/backend/src/cam/cam.controller.ts
@@ -18,9 +18,23 @@ export class CamController {
     return `Test Get API 3 received ${id}`;
   }
   @Post('/create-room')
-  test4(@Body() payload: { roomid: string }): string {
+  createRoom(@Body() payload: { roomid: string }): string {
+    const { roomid } = payload;
     let statusCode = 201;
-    if (!this.camService.createRoom(payload.roomid)) statusCode = 500;
+    if (!this.camService.createRoom(roomid)) statusCode = 500;
+    console.log(this.camService.showMap());
+    return Object.assign({
+      statusCode,
+      data: payload,
+      statusMsg: 'created successfully',
+    });
+  }
+
+  @Post('/is-room-exist')
+  isRoomExist(@Body() payload: { roomid: string }): string {
+    const { roomid } = payload;
+    let statusCode = 201;
+    if (!this.camService.isRoomExist(roomid)) statusCode = 500;
     console.log(this.camService.showMap());
     return Object.assign({
       statusCode,

--- a/backend/src/cam/cam.controller.ts
+++ b/backend/src/cam/cam.controller.ts
@@ -1,0 +1,31 @@
+import { Controller, Get, Post, Param, Body, Query } from '@nestjs/common';
+
+import { CamService } from './cam.service';
+
+@Controller('cam')
+export class CamController {
+  constructor(private camService: CamService) {}
+  @Get('/test')
+  test(): string {
+    return 'Test Get API Value';
+  }
+  @Get('/test2/:id')
+  test2(@Param('id') id: string): string {
+    return `Test Get API 2 received ${id}`;
+  }
+  @Get('/test3')
+  test3(@Query('id') id: string): string {
+    return `Test Get API 3 received ${id}`;
+  }
+  @Post('/create-room')
+  test4(@Body() payload: { roomid: string }): string {
+    let statusCode = 201;
+    if (!this.camService.createRoom(payload.roomid)) statusCode = 500;
+    console.log(this.camService.showMap());
+    return Object.assign({
+      statusCode,
+      data: payload,
+      statusMsg: 'created successfully',
+    });
+  }
+}

--- a/backend/src/cam/cam.gateway.ts
+++ b/backend/src/cam/cam.gateway.ts
@@ -9,8 +9,9 @@ export class CamGateway {
   constructor(private camService: CamService) {
     this.camService.createRoom('1');
   }
+
   @SubscribeMessage('joinRoom')
-  handleMessage(
+  handleJoinRoom(
     client: Socket,
     payload: { roomId: string; userId: string; status: Status },
   ): void {
@@ -19,19 +20,41 @@ export class CamGateway {
     this.camService.joinRoom(roomId, userId, status);
     client.to(roomId).emit('userConnected', { userId });
 
+    client.data.roomId = roomId;
+    client.data.userId = userId;
+
+    console.log(client.data);
+
     client.on('disconnect', () => {
       client.to(roomId).emit('userDisconnected', { userId });
       this.camService.exitRoom(roomId, userId);
     });
+  }
 
-    client.on('updateUserStatus', ({ status }) => {
-      this.camService.updateStatus(roomId, userId, status);
-      client.to(roomId).emit('userStatus', { userId, status });
-    });
+  @SubscribeMessage('exitRoom')
+  handleExitRoom(client: Socket): void {
+    const { roomId, userId } = client.data;
+    client.to(roomId).emit('userDisconnected', { userId });
+    this.camService.exitRoom(roomId, userId);
+    client.data.roomId = null;
+    client.data.userId = null;
+  }
 
-    client.on('getUserStatus', ({ userId }) => {
-      const status = this.camService.getStatus(roomId, userId);
-      client.emit('userStatus', { userId, status });
-    });
+  @SubscribeMessage('updateUserStatus')
+  handleUpdateUserStatus(client: Socket, payload: { status: Status }) {
+    if (!client.data.roomId || !client.data.userId) return;
+    const { roomId, userId } = client.data;
+    const { status } = payload;
+    this.camService.updateStatus(roomId, userId, status);
+    client.to(roomId).emit('userStatus', { userId, status });
+  }
+
+  @SubscribeMessage('getUserStatus')
+  handleGetUserStatus(client: Socket, payload: { userId: string }) {
+    if (!client.data.roomId || !client.data.userId) return;
+    const { roomId } = client.data;
+    const { userId } = payload;
+    const status = this.camService.getStatus(roomId, userId);
+    client.emit('userStatus', { userId, status });
   }
 }

--- a/backend/src/cam/cam.module.ts
+++ b/backend/src/cam/cam.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
 import { CamGateway } from './cam.gateway';
 import { CamService } from './cam.service';
+import { CamController } from './cam.controller';
 
 @Module({
   providers: [CamGateway, CamService],
+  controllers: [CamController],
 })
 export class CamModule {}

--- a/backend/src/cam/cam.service.ts
+++ b/backend/src/cam/cam.service.ts
@@ -10,6 +10,9 @@ export class CamService {
   showMap() {
     return this.map;
   }
+  isRoomExist(roomId: string): boolean {
+    return this.map.has(roomId) ? true : false;
+  }
   createRoom(roomId: string): boolean {
     if (this.map.get(roomId)) return false;
     this.map.set(roomId, []);

--- a/backend/src/cam/cam.service.ts
+++ b/backend/src/cam/cam.service.ts
@@ -25,7 +25,8 @@ export class CamService {
   }
   exitRoom(roomId: string, userId: string) {
     const room = this.map.get(roomId).filter((user) => user.userId !== userId);
-    this.map.set(roomId, room);
+    if (!room.length) this.map.delete(roomId);
+    else this.map.set(roomId, room);
   }
   updateStatus(roomId: string, userId: string, status: Status) {
     const user = this.map.get(roomId).find((user) => user.userId === userId);

--- a/backend/src/cam/cam.service.ts
+++ b/backend/src/cam/cam.service.ts
@@ -7,11 +7,18 @@ export class CamService {
   constructor() {
     this.map = new Map();
   }
-  createRoom(roomId: string) {
-    this.map.set(roomId, []);
+  showMap() {
+    return this.map;
   }
-  joinRoom(roomId: string, userId: string, status: Status) {
+  createRoom(roomId: string): boolean {
+    if (this.map.get(roomId)) return false;
+    this.map.set(roomId, []);
+    return true;
+  }
+  joinRoom(roomId: string, userId: string, status: Status): boolean {
+    if (!this.map.get(roomId)) return false;
     this.map.get(roomId).push({ userId, status });
+    return true;
   }
   exitRoom(roomId: string, userId: string) {
     const room = this.map.get(roomId).filter((user) => user.userId !== userId);

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,6 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { RecoilRoot } from 'recoil';
-import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
+import { BrowserRouter as Router, Route, Routes, Navigate } from 'react-router-dom';
 
 import Cam from './components/Cam/Cam';
 import LoginMain from './components/LoginPage/LoginMain';
@@ -14,13 +14,15 @@ type UserInfo = {
 function App(): JSX.Element {
   const [userInfo, setUserInfo] = useState<UserInfo | null>({ roomId: null, nickname: null });
 
+  const isNicknameNull = () => userInfo && !!userInfo.nickname;
+
   return (
     <Router>
       <RecoilRoot>
         <Routes>
           <Route path="/" element={<LoginMain />} />
+          <Route path="/cam" element={isNicknameNull() ? <Cam userInfo={userInfo} /> : <Navigate to="/rooms" />} />
           <Route path="/rooms" element={<CamRooms handleUserInfo={setUserInfo} />} />
-          <Route path="/cam" element={<Cam userInfo={userInfo} />} />
         </Routes>
       </RecoilRoot>
     </Router>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,15 +14,13 @@ type UserInfo = {
 function App(): JSX.Element {
   const [userInfo, setUserInfo] = useState<UserInfo | null>({ roomId: null, nickname: null });
 
-  const isNicknameNull = () => userInfo && !!userInfo.nickname;
-
   return (
     <Router>
       <RecoilRoot>
         <Routes>
           <Route path="/" element={<LoginMain />} />
-          <Route path="/cam" element={isNicknameNull() ? <Cam userInfo={userInfo} /> : <Navigate to="/rooms" />} />
-          <Route path="/rooms" element={<CamRooms handleUserInfo={setUserInfo} />} />
+          <Route path="/cam" element={<Cam userInfo={userInfo} setUserInfo={setUserInfo} />} />
+          <Route path="/rooms" element={<CamRooms setUserInfo={setUserInfo} />} />
         </Routes>
       </RecoilRoot>
     </Router>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,7 +7,7 @@ import LoginMain from './components/LoginPage/LoginMain';
 import CamRooms from './components/Main/CamRooms';
 
 type UserInfo = {
-  roomId: number | null;
+  roomId: string | null;
   nickname: string | null;
 };
 

--- a/frontend/src/components/Cam/Cam.tsx
+++ b/frontend/src/components/Cam/Cam.tsx
@@ -30,7 +30,7 @@ const UpperTab = styled.div`
 `;
 
 type UserInfo = {
-  roomId: number | null;
+  roomId: string | null;
   nickname: string | null;
 };
 

--- a/frontend/src/components/Cam/Cam.tsx
+++ b/frontend/src/components/Cam/Cam.tsx
@@ -39,9 +39,11 @@ type UserInfo = {
 
 type CamProps = {
   userInfo: UserInfo | null;
+  setUserInfo: React.Dispatch<React.SetStateAction<UserInfo | null>>;
 };
 
-function Cam({ userInfo }: CamProps): JSX.Element {
+function Cam(props: CamProps): JSX.Element {
+  const { userInfo, setUserInfo } = props;
   const [isUserListTabActive, setUserListTabActive] = useState<boolean>(true);
   const [isChattingTabActive, setChattingTabActive] = useState<boolean>(true);
   const [isMouseOnCamPage, setMouseOnCampPage] = useState<boolean>(false);
@@ -64,25 +66,50 @@ function Cam({ userInfo }: CamProps): JSX.Element {
       setMouseOnCampPage(false);
     }
   };
+
+  const onSubmitNicknameForm = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const { currentTarget } = e;
+    const formData: FormData = new FormData(currentTarget);
+    const receivedData: UserInfo = { nickname: null, roomId: null };
+    formData.forEach((val, key) => {
+      if (key === 'nickname') receivedData.nickname = val.toString().trim();
+    });
+    setUserInfo(receivedData);
+  };
+
   useEffect(() => {
     return () => {
       socket.emit('exitRoom');
     };
   }, []);
 
+  useEffect(() => {
+    console.log(userInfo);
+  }, [userInfo]);
+
   return (
     <Container className="cam" onMouseOver={handleMouseOverCamPage} onMouseLeave={handleMouseOutCamPage}>
-      <CamStore>
-        <UpperTab>
-          <MainScreen tabActive={{ isUserListTabActive, isChattingTabActive }} isMouseOnCamPage={isMouseOnCamPage} />
-          <UserListTab isUserListTabActive={isUserListTabActive} userInfo={userInfo} />
-          <ChattingTab isChattingTabActive={isChattingTabActive} isMouseOnCamPage={isMouseOnCamPage} />
-        </UpperTab>
-        <ButtonBar
-          handleTab={{ handleUserListTabActive, handleChattingTabActive }}
-          isMouseOnCamPage={isMouseOnCamPage}
-        />
-      </CamStore>
+      {!userInfo?.nickname ? (
+        <div>
+          <form onSubmit={onSubmitNicknameForm}>
+            <input name="nickname" placeholder="닉네임을 입력해주세요" required />
+            <button type="submit">입력</button>
+          </form>
+        </div>
+      ) : (
+        <CamStore>
+          <UpperTab>
+            <MainScreen tabActive={{ isUserListTabActive, isChattingTabActive }} isMouseOnCamPage={isMouseOnCamPage} />
+            <UserListTab isUserListTabActive={isUserListTabActive} userInfo={userInfo} />
+            <ChattingTab isChattingTabActive={isChattingTabActive} isMouseOnCamPage={isMouseOnCamPage} />
+          </UpperTab>
+          <ButtonBar
+            handleTab={{ handleUserListTabActive, handleChattingTabActive }}
+            isMouseOnCamPage={isMouseOnCamPage}
+          />
+        </CamStore>
+      )}
     </Container>
   );
 }

--- a/frontend/src/components/Cam/Cam.tsx
+++ b/frontend/src/components/Cam/Cam.tsx
@@ -1,11 +1,14 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 
+import { useRecoilValue } from 'recoil';
 import ButtonBar from './ButtonBar';
 import ChattingTab from './ChattingTab';
 import MainScreen from './MainScreen';
 import CamStore from './CamStore';
 import UserListTab from './UserListTab';
+
+import socketState from '../../atoms/socket';
 
 const Container = styled.div`
   width: 100vw;
@@ -42,6 +45,7 @@ function Cam({ userInfo }: CamProps): JSX.Element {
   const [isUserListTabActive, setUserListTabActive] = useState<boolean>(true);
   const [isChattingTabActive, setChattingTabActive] = useState<boolean>(true);
   const [isMouseOnCamPage, setMouseOnCampPage] = useState<boolean>(false);
+  const socket = useRecoilValue(socketState);
 
   const handleUserListTabActive = (): void => {
     setUserListTabActive(!isUserListTabActive);
@@ -60,6 +64,11 @@ function Cam({ userInfo }: CamProps): JSX.Element {
       setMouseOnCampPage(false);
     }
   };
+  useEffect(() => {
+    return () => {
+      socket.emit('exitRoom');
+    };
+  }, []);
 
   return (
     <Container className="cam" onMouseOver={handleMouseOverCamPage} onMouseLeave={handleMouseOutCamPage}>

--- a/frontend/src/components/Cam/CamStore.tsx
+++ b/frontend/src/components/Cam/CamStore.tsx
@@ -13,9 +13,11 @@ export const CamStoreContext = createContext<React.ComponentState>(null);
 function CamStore(props: CamStoreProps): JSX.Element {
   const { children } = props;
   const socket = useRecoilValue(SocketState);
+  const currentURL = new URL(window.location.href);
+  const roomId = currentURL.searchParams.get('roomid');
   const { localStatus, localStream, setLocalStatus, screenList } = useUserMedia({
     socket,
-    roomId: '1',
+    roomId,
   });
 
   return (

--- a/frontend/src/components/Cam/UserListTab.tsx
+++ b/frontend/src/components/Cam/UserListTab.tsx
@@ -33,7 +33,7 @@ const Container = styled.div<{ isActive: boolean }>`
 `;
 
 type UserInfo = {
-  roomId: number | null;
+  roomId: string | null;
   nickname: string | null;
 };
 

--- a/frontend/src/components/Cam/UserListTab.tsx
+++ b/frontend/src/components/Cam/UserListTab.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useContext, useEffect } from 'react';
 import styled from 'styled-components';
 
 import UserScreen from './UserScreen';

--- a/frontend/src/components/Cam/UserScreen.tsx
+++ b/frontend/src/components/Cam/UserScreen.tsx
@@ -49,7 +49,6 @@ function UserScreen(props: UserScreenProps): JSX.Element {
         setStatus(payload.status);
       }
     });
-
     socket.emit('getUserStatus', { userId });
   }, []);
 

--- a/frontend/src/components/Main/CamRooms.tsx
+++ b/frontend/src/components/Main/CamRooms.tsx
@@ -112,7 +112,7 @@ function CamRooms({ handleUserInfo }: CamRoomsProps): JSX.Element {
 
     const { nickname, roomId } = receivedData;
 
-    if (nickname === null || !nickname.length || Number.isNaN(roomId)) return;
+    if (!nickname || !roomId) return;
 
     handleUserInfo(receivedData);
     const response = await fetch('/cam/create-room/', {
@@ -129,7 +129,7 @@ function CamRooms({ handleUserInfo }: CamRoomsProps): JSX.Element {
     else if (statusCode === 500) alert('이미 존재하는 방 입니다.');
   };
 
-  const onSumbitJoinForm = (e: React.FormEvent<HTMLFormElement>): void => {
+  const onSumbitJoinForm = async (e: React.FormEvent<HTMLFormElement>): Promise<void> => {
     e.preventDefault();
     const { currentTarget } = e;
     const formData: FormData = new FormData(currentTarget);
@@ -140,10 +140,21 @@ function CamRooms({ handleUserInfo }: CamRoomsProps): JSX.Element {
     });
 
     const { nickname, roomId } = receivedData;
-    if (nickname === null || !nickname.length || Number.isNaN(roomId)) return;
+    if (!nickname || !roomId) return;
 
     handleUserInfo(receivedData);
-    navigate(`/cam?roomid=${roomId}`);
+    const response = await fetch('/cam/is-room-exist/', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        roomid: roomId,
+      }),
+    });
+    const { statusCode } = await response.json();
+    if (statusCode === 201) navigate(`/cam?roomid=${roomId}`);
+    else if (statusCode === 500) alert('존재하지 않는 방 입니다.');
   };
 
   return (
@@ -153,11 +164,11 @@ function CamRooms({ handleUserInfo }: CamRoomsProps): JSX.Element {
           <BoxTag>Create Room</BoxTag>
           <InputDiv>
             <InputTag>Nickname</InputTag>
-            <Input name="nickname" placeholder="닉네임을 입력하세요" />
+            <Input name="nickname" placeholder="닉네임을 입력하세요" required />
           </InputDiv>
           <InputDiv>
             <InputTag>Room Number</InputTag>
-            <Input name="roomid" placeholder="방 번호를 입력하세요" />
+            <Input name="roomid" placeholder="방 번호를 입력하세요" required />
           </InputDiv>
           <SubmitButton type="submit">Create</SubmitButton>
         </DivForm>
@@ -165,11 +176,11 @@ function CamRooms({ handleUserInfo }: CamRoomsProps): JSX.Element {
           <BoxTag>Join Room</BoxTag>
           <InputDiv>
             <InputTag>Nickname</InputTag>
-            <Input name="nickname" placeholder="닉네임을 입력하세요" />
+            <Input name="nickname" placeholder="닉네임을 입력하세요" required />
           </InputDiv>
           <InputDiv>
             <InputTag>Room Number</InputTag>
-            <Input name="roomid" placeholder="방 번호를 입력하세요" />
+            <Input name="roomid" placeholder="방 번호를 입력하세요" required />
           </InputDiv>
           <SubmitButton type="submit">Join</SubmitButton>
         </DivForm>

--- a/frontend/src/components/Main/CamRooms.tsx
+++ b/frontend/src/components/Main/CamRooms.tsx
@@ -95,10 +95,11 @@ type UserInfo = {
 };
 
 type CamRoomsProps = {
-  handleUserInfo: React.Dispatch<React.SetStateAction<UserInfo | null>>;
+  setUserInfo: React.Dispatch<React.SetStateAction<UserInfo | null>>;
 };
 
-function CamRooms({ handleUserInfo }: CamRoomsProps): JSX.Element {
+function CamRooms(props: CamRoomsProps): JSX.Element {
+  const { setUserInfo } = props;
   const navigate = useNavigate();
   const onSumbitCreateForm = async (e: React.FormEvent<HTMLFormElement>): Promise<void> => {
     e.preventDefault();
@@ -114,7 +115,7 @@ function CamRooms({ handleUserInfo }: CamRoomsProps): JSX.Element {
 
     if (!nickname || !roomId) return;
 
-    handleUserInfo(receivedData);
+    setUserInfo(receivedData);
     const response = await fetch('/cam/create-room/', {
       method: 'POST',
       headers: {
@@ -142,7 +143,7 @@ function CamRooms({ handleUserInfo }: CamRoomsProps): JSX.Element {
     const { nickname, roomId } = receivedData;
     if (!nickname || !roomId) return;
 
-    handleUserInfo(receivedData);
+    setUserInfo(receivedData);
     const response = await fetch('/cam/is-room-exist/', {
       method: 'POST',
       headers: {

--- a/frontend/src/components/Main/CamRooms.tsx
+++ b/frontend/src/components/Main/CamRooms.tsx
@@ -90,7 +90,7 @@ const SubmitButton = styled.button`
 `;
 
 type UserInfo = {
-  roomId: number | null;
+  roomId: string | null;
   nickname: string | null;
 };
 
@@ -100,33 +100,50 @@ type CamRoomsProps = {
 
 function CamRooms({ handleUserInfo }: CamRoomsProps): JSX.Element {
   const navigate = useNavigate();
-  const onSumbitCreateForm = (e: React.FormEvent<HTMLFormElement>): void => {
+  const onSumbitCreateForm = async (e: React.FormEvent<HTMLFormElement>): Promise<void> => {
     e.preventDefault();
     const { currentTarget } = e;
     const formData: FormData = new FormData(currentTarget);
     const receivedData: UserInfo = { nickname: null, roomId: null };
     formData.forEach((val, key) => {
       if (key === 'nickname') receivedData.nickname = val.toString().trim();
-      if (key === 'roomid') receivedData.roomId = parseInt(val.toString(), 10);
+      if (key === 'roomid') receivedData.roomId = val.toString();
     });
 
     const { nickname, roomId } = receivedData;
 
     if (nickname === null || !nickname.length || Number.isNaN(roomId)) return;
-    console.log(receivedData);
+
     handleUserInfo(receivedData);
-    navigate(`/cam?roomid=${roomId}`);
+    const response = await fetch('/cam/create-room/', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        roomid: roomId,
+      }),
+    });
+    const { statusCode } = await response.json();
+    if (statusCode === 201) navigate(`/cam?roomid=${roomId}`);
+    else if (statusCode === 500) alert('이미 존재하는 방 입니다.');
   };
 
   const onSumbitJoinForm = (e: React.FormEvent<HTMLFormElement>): void => {
     e.preventDefault();
     const { currentTarget } = e;
     const formData: FormData = new FormData(currentTarget);
-
-    formData.forEach((val) => {
-      console.log(val);
+    const receivedData: UserInfo = { nickname: null, roomId: null };
+    formData.forEach((val, key) => {
+      if (key === 'nickname') receivedData.nickname = val.toString().trim();
+      if (key === 'roomid') receivedData.roomId = val.toString();
     });
-    // navigate(`/cam`);
+
+    const { nickname, roomId } = receivedData;
+    if (nickname === null || !nickname.length || Number.isNaN(roomId)) return;
+
+    handleUserInfo(receivedData);
+    navigate(`/cam?roomid=${roomId}`);
   };
 
   return (

--- a/frontend/src/hooks/useUserMedia.ts
+++ b/frontend/src/hooks/useUserMedia.ts
@@ -3,7 +3,7 @@ import { useEffect, useState, useRef } from 'react';
 import { Socket } from 'socket.io-client';
 import type { Status, Screen } from '../types/cam';
 
-export default function useUserMedia({ socket, roomId }: { socket: Socket; roomId: string }): {
+export default function useUserMedia({ socket, roomId }: { socket: Socket; roomId: string | null }): {
   localStream: MediaStream;
   setLocalStream: typeof setLocalStream;
   localStatus: Status;

--- a/frontend/src/hooks/useUserMedia.ts
+++ b/frontend/src/hooks/useUserMedia.ts
@@ -56,7 +56,6 @@ export default function useUserMedia({ socket, roomId }: { socket: Socket; roomI
     myPeerRef.current.on('open', (userId) => {
       peerIdRef.current = userId;
     });
-
     getUserMedia();
   }, []);
 
@@ -109,7 +108,7 @@ export default function useUserMedia({ socket, roomId }: { socket: Socket; roomI
   }, [localStream]);
 
   useEffect(() => {
-    socket.emit('updateUserStatus', { userId: peerIdRef.current, status: localStatus });
+    if (peerIdRef.current) socket.emit('updateUserStatus', { status: localStatus });
   }, [localStatus]);
 
   return { localStream, setLocalStream, localStatus, setLocalStatus, screenList };


### PR DESCRIPTION
- CamService의 Map과 상호작용하는 CamController 코드 작성
    + CamController에 CamService의 createRoom 메서드로 새로운 방을 생성하는 `/create-room` API를 작성하였습니다.
    + CamRooms에서 Form을 통해 작성된 Input으로 API를 사용하여 backend의 CamService와 상호작용하는 코드를 작성하였습니다.
    + backend의 CamService에서 현재 Map을 확인하기 위한 임시 메서드인 showMap을 추가하고, createRoom과 joinRoom에서 성공 여부를 확인할 수 있도록 boolean 반환형을 추가하였습니다.
    + UserInfo State 에서 roomId의 타입을 string | null로 변경하였습니다.
    + CamStore에서 전달하는 roomId를 현재 주소의 쿼리스트링 중 roomid 항목을 참조하여 전달하도록 수정하였습니다.
    + useUserMedia의 props 중 roomId의 타입을 string | null 로 수정하였습니다.
- CamRooms에서 존재하는 방만 접속할 수 있도록 함
    + CamService에 roomId에 대한 방이 존재하는지 확인하는 isRoomExist 메서드를 추가하였습니다.
    + CamController에 roomId에 대한 방이 존재하는지에 대한 결과를 알려주는 `/cam/is-room-exist` API를 추가하였습니다.
    + CamRooms의 Join Form에서는 관련 API를 사용하여 현재 입력된 방이 존재하는지 확인 후 접속합니다.
- 뒤로가기 버튼으로 방을 나갈 수 있도록 코드 작성
    + Cam에서 뒤로가기로 방을 나갔을 때 다른 사용자들의 클라이언트에도 이 것들이 반영될 수 있도록 backend와 frontend 코드를 수정하였습니다.
    + backend에서 CanGateway의 Socket 관련 이벤트들을 분리하였습니다.
    + CamService 에서 이제 ExitRoom 이벤트 발생 시 방에 아무도 없다면 해당 roomId를 Map에서 삭제하도록 구현하였습니다.
    + 하지만 현재 CamStore의 Context 관련 오류로 추정되는 이슈가 있습니다. 이 부분은 팀원들과 상의해야 합니다.
- Cam에 URL로 직접 접속할 때의 컴포넌트 추가
    + 이제 존재하는 방에 직접 접속을 할 경우 닉네임을 입력해야만 기존의 Cam 컴포넌트들을 랜더링 할 수 있습니다.
    + 아직 이를 별도의 컴포넌트로 분리하지 않았으므로 해당 작업이 필요합니다.
    + 아직 존재하지 않는 방에 접속하려 할 때의 케이스를 분리하지 않았으므로 추가 작업이 필요합니다.