### PR TITLE
MainScreen에 각 유저 screen 컴포넌트 격자배치 구현

### DIFF
--- a/frontend/src/components/Cam/DefaultScreen.tsx
+++ b/frontend/src/components/Cam/DefaultScreen.tsx
@@ -2,10 +2,14 @@ import styled from 'styled-components';
 
 const Container = styled.div`
   width: 100%;
+  max-height: 100%;
+  display: flex;
+  justify-content: center;
 `;
 
 const DefaultImg = styled.img`
-  width: 100%;
+  max-width: 100%;
+  max-height: 100%;
 `;
 
 function DefaultScreen(): JSX.Element {

--- a/frontend/src/components/Cam/LocalUserScreen.tsx
+++ b/frontend/src/components/Cam/LocalUserScreen.tsx
@@ -1,21 +1,30 @@
 import React, { useContext, useEffect, useRef } from 'react';
 import styled from 'styled-components';
+
 import DefaultScreen from './DefaultScreen';
 import { CamStoreContext } from './CamStore';
+import StreamStatusIndicator from './StreamStatusIndicator';
 
-const Container = styled.div`
-  margin-top: 10px;
-  &:last-child {
-    margin-bottom: 10px;
-  }
+const Container = styled.div<{ screenWidth: string }>`
+  width: ${(props) => props.screenWidth};
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  height: 90%;
 `;
 
-const Video = styled.video`
-  height: auto;
+const Video = styled.video<{ screenWidth: string }>`
+  max-height: 100%;
   width: 100%;
 `;
 
-function LocalUserScreen(): JSX.Element {
+type LocalUserScreenProps = {
+  screenWidth: string;
+};
+
+function LocalUserScreen(props: LocalUserScreenProps): JSX.Element {
+  const { screenWidth } = props;
   const videoRef = useRef<HTMLVideoElement>(null);
   const { localStream, localStatus } = useContext(CamStoreContext);
 
@@ -29,15 +38,15 @@ function LocalUserScreen(): JSX.Element {
   });
 
   return (
-    <Container>
-      <div>{`video ${localStatus.video} audio ${localStatus.audio}`}</div>
+    <Container screenWidth={screenWidth}>
       {localStatus.stream && localStatus.video ? (
-        <Video ref={videoRef} playsInline autoPlay muted>
+        <Video screenWidth={screenWidth} ref={videoRef} playsInline autoPlay muted>
           <track kind="captions" />
         </Video>
       ) : (
         <DefaultScreen />
       )}
+      <StreamStatusIndicator micStatus={localStatus.audio} videoStatus={localStatus.video} />
     </Container>
   );
 }

--- a/frontend/src/components/Cam/MainScreen.tsx
+++ b/frontend/src/components/Cam/MainScreen.tsx
@@ -1,10 +1,18 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import styled from 'styled-components';
+
+import { CamStoreContext } from './CamStore';
+import ScreenRow from './ScreenRow';
+import type { Screen } from '../../types/cam';
 
 const Container = styled.div<{ activeTab: string[]; isMouseOnCamPage: boolean }>`
   width: ${(props) => props.activeTab[0]};
   height: ${(props) => (props.isMouseOnCamPage ? '90vh' : '98vh')};
-  background-color: #ffffff;
+  background-color: black;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-evenly;
+  align-items: center;
   transition: all 0.5s ease;
 `;
 
@@ -13,9 +21,33 @@ type MainScreenProps = {
   isMouseOnCamPage: boolean;
 };
 
+const getScreenListOfRows = (screenListInfo: Array<Screen>) => {
+  const screenListOfRows: Array<Array<Screen>> = [];
+  const maxColumns = screenListInfo.length >= 4 ? 3 : 2;
+  let screenListOfRow: Array<Screen> = [];
+  let beforeRow = 0;
+
+  screenListInfo.forEach((screen, index) => {
+    const currentRow = Math.floor((index + 1) / maxColumns);
+
+    if (beforeRow !== currentRow) {
+      beforeRow = currentRow;
+      screenListOfRows.push(screenListOfRow);
+      screenListOfRow = [];
+    }
+    screenListOfRow.push(screen);
+  });
+  if (screenListOfRow.length !== 0) {
+    screenListOfRows.push(screenListOfRow);
+  }
+  return screenListOfRows;
+};
+
 function MainScreen(props: MainScreenProps): JSX.Element {
   const { tabActive, isMouseOnCamPage } = props;
   const { isChattingTabActive } = tabActive;
+  const { screenList } = useContext(CamStoreContext);
+  const screenListOfRows = getScreenListOfRows(screenList);
 
   const countActiveTab = (): string[] => {
     if (isChattingTabActive) return ['70vw', '98vw'];
@@ -23,13 +55,22 @@ function MainScreen(props: MainScreenProps): JSX.Element {
   };
 
   const handleAnimationEnd = (e: React.AnimationEvent<HTMLDivElement>) => {
-    console.log(e.currentTarget.style.animation);
     e.currentTarget.style.animation = 'none';
   };
 
   return (
     <Container activeTab={countActiveTab()} onAnimationEnd={handleAnimationEnd} isMouseOnCamPage={isMouseOnCamPage}>
-      MainScreen
+      {screenListOfRows.length === 0 ? <ScreenRow screenListOfRow={[]} rowIndex={0} numOfRows={1} /> : ''}
+      {screenListOfRows.map((screenListOfRow: Array<Screen>, index) => {
+        return (
+          <ScreenRow
+            key={Math.random()}
+            screenListOfRow={screenListOfRow}
+            rowIndex={index}
+            numOfRows={screenListOfRows.length}
+          />
+        );
+      })}
     </Container>
   );
 }

--- a/frontend/src/components/Cam/ScreenRow.tsx
+++ b/frontend/src/components/Cam/ScreenRow.tsx
@@ -1,0 +1,56 @@
+import React, { useContext } from 'react';
+import styled from 'styled-components';
+
+import type { Screen } from '../../types/cam';
+import UserScreen from './UserScreen';
+import LocalUserScreen from './LocalUserScreen';
+
+const Container = styled.div<{ numOfRows: number }>`
+  width: 90%;
+  height: ${(props) => {
+    if (props.numOfRows === 1) {
+      return '100';
+    }
+    if (props.numOfRows === 2) {
+      return '40';
+    }
+    return '30';
+  }}%;
+  max-height: 70vh;
+  padding: 0 10px;
+  display: flex;
+  justify-content: space-evenly;
+  align-items: center;
+  overflow-y: auto;
+`;
+
+type ScreenRowProps = {
+  screenListOfRow: Array<Screen>;
+  rowIndex: number;
+  numOfRows: number;
+};
+
+const getScreenWidth = (numOfRows: number, lengthOfRow: number) => {
+  if (numOfRows === 1) {
+    return lengthOfRow === 0 ? '100%' : '40%';
+  }
+  if (numOfRows === 2) {
+    return '40%';
+  }
+  return '30%';
+};
+function ScreenRow(props: ScreenRowProps): JSX.Element {
+  const { screenListOfRow, rowIndex, numOfRows } = props;
+  const screenWidth = getScreenWidth(numOfRows, screenListOfRow.length);
+
+  return (
+    <Container numOfRows={numOfRows}>
+      {rowIndex === 0 ? <LocalUserScreen screenWidth={screenWidth} /> : ''}
+      {screenListOfRow.map((screen: Screen) => (
+        <UserScreen key={screen.userId} stream={screen.stream} userId={screen.userId} screenWidth={screenWidth} />
+      ))}
+    </Container>
+  );
+}
+
+export default ScreenRow;

--- a/frontend/src/components/Cam/StreamStatusIndicator.tsx
+++ b/frontend/src/components/Cam/StreamStatusIndicator.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import { ReactComponent as MicIcon } from '../../assets/icons/mic.svg';
+import { ReactComponent as VideoIcon } from '../../assets/icons/video.svg';
+
+const Container = styled.div`
+  margin-top: 2px;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+`;
+
+const Button = styled.div<{ status?: boolean }>`
+  width: 2vw;
+  height: 2vh;
+
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: center;
+  color: ${(props) => (props.status ? '#00ff2e' : 'red')};
+
+  &:hover {
+    color: ${(props) => (props.status ? 'red' : '#00ff2e')};
+    transition: all 0.5s;
+    cursor: pointer;
+  }
+
+  svg {
+    min-width: 6vh;
+    height: 6vh;
+  }
+`;
+
+type StreamStatusIndicatorProps = {
+  micStatus: boolean;
+  videoStatus: boolean;
+};
+function StreamStatusIndicator(props: StreamStatusIndicatorProps): JSX.Element {
+  const { micStatus, videoStatus } = props;
+
+  return (
+    <Container>
+      <Button status={micStatus}>
+        <MicIcon />
+      </Button>
+      <Button status={videoStatus}>
+        <VideoIcon />
+      </Button>
+    </Container>
+  );
+}
+
+export default StreamStatusIndicator;

--- a/frontend/src/components/Cam/UserListTab.tsx
+++ b/frontend/src/components/Cam/UserListTab.tsx
@@ -12,7 +12,7 @@ const Container = styled.div<{ isActive: boolean }>`
   width: 18vw;
   max-height: 70vh;
   padding: 0 10px;
-  background-color: #c4c4c4;
+  background-color: black;
   display: ${(props) => (props.isActive ? 'block' : 'none')};
   overflow-y: auto;
 
@@ -45,6 +45,7 @@ type UserListProps = {
 function UserListTab(props: UserListProps): JSX.Element {
   const { isUserListTabActive, userInfo } = props;
   const { screenList } = useContext(CamStoreContext);
+  const screenWidth = '100%';
 
   return (
     <Draggable
@@ -55,9 +56,9 @@ function UserListTab(props: UserListProps): JSX.Element {
       isActive={isUserListTabActive}
     >
       <Container isActive={isUserListTabActive}>
-        <LocalUserScreen />
+        <LocalUserScreen screenWidth={screenWidth} />
         {screenList.map((screen: Screen) => (
-          <UserScreen key={screen.userId} stream={screen.stream} userId={screen.userId} />
+          <UserScreen key={screen.userId} stream={screen.stream} userId={screen.userId} screenWidth={screenWidth} />
         ))}
       </Container>
     </Draggable>

--- a/frontend/src/components/Cam/UserScreen.tsx
+++ b/frontend/src/components/Cam/UserScreen.tsx
@@ -5,26 +5,30 @@ import styled from 'styled-components';
 import socketState from '../../atoms/socket';
 import DefaultScreen from './DefaultScreen';
 import type { Status } from '../../types/cam';
+import StreamStatusIndicator from './StreamStatusIndicator';
 
 type UserScreenProps = {
   stream: MediaStream | undefined;
   userId: string;
+  screenWidth: string;
 };
 
-const Container = styled.div`
-  margin-top: 10px;
-  &:last-child {
-    margin-bottom: 10px;
-  }
+const Container = styled.div<{ screenWidth: string }>`
+  width: ${(props) => props.screenWidth};
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  height: 90%;
 `;
 
-const Video = styled.video`
-  height: auto;
+const Video = styled.video<{ screenWidth: string }>`
+  max-height: 100%;
   width: 100%;
 `;
 
 function UserScreen(props: UserScreenProps): JSX.Element {
-  const { stream, userId } = props;
+  const { stream, userId, screenWidth } = props;
   const socket = useRecoilValue(socketState);
   const videoRef = useRef<HTMLVideoElement>(null);
 
@@ -54,15 +58,15 @@ function UserScreen(props: UserScreenProps): JSX.Element {
   }, []);
 
   return (
-    <Container>
-      <div>{`video ${status.video} audio ${status.audio}`}</div>
+    <Container screenWidth={screenWidth}>
       {status.stream && status.video ? (
-        <Video ref={videoRef} playsInline autoPlay muted>
+        <Video screenWidth={screenWidth} ref={videoRef} playsInline autoPlay>
           <track kind="captions" />
         </Video>
       ) : (
         <DefaultScreen />
       )}
+      <StreamStatusIndicator micStatus={status.audio} videoStatus={status.video} />
     </Container>
   );
 }


### PR DESCRIPTION
- MainScreen에 모든 유저의 화면을 인원수에 따라 격자배치를 하도록 구현했습니다.

> 본인포함 4명 이하일 때 : 각 row별 최대 2명 표시
본인포함 4명 초과일 때 : 각 row별 최대 3명 표시

- screen컴포넌트 하단에 사용자의 마이크와 비디오 상태를 표시하는 인디케이터 컴포넌트를 추가하였습니다.

### 사용자가 1명일 때
![캡처1](https://user-images.githubusercontent.com/62635664/141151828-00298f17-da5e-40c7-840c-a0e44c64e19b.PNG)

### 사용자가 3명일 때
![캡처2](https://user-images.githubusercontent.com/62635664/141151867-272a7df6-f431-4882-a194-27dda8840b5d.PNG)

### 사용자가 7명일 때
![캡처7](https://user-images.githubusercontent.com/62635664/141151893-88b87316-bf03-4f8d-9b85-a34db405f765.PNG)

