### PR TITLE
메인 페이지 UI 변경, 닉네임 로직 변경

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,20 +1,17 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { RecoilRoot } from 'recoil';
 import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
 
 import Cam from './components/Cam/Cam';
 import CamRooms from './components/Main/CamRooms';
-import { UserInfo } from './types/cam';
 
 function App(): JSX.Element {
-  const [userInfo, setUserInfo] = useState<UserInfo>({ roomId: null, nickname: null });
-
   return (
     <Router>
       <RecoilRoot>
         <Routes>
-          <Route path="/" element={<CamRooms userInfo={userInfo} setUserInfo={setUserInfo} />} />
-          <Route path="/cam" element={<Cam userInfo={userInfo} setUserInfo={setUserInfo} />} />
+          <Route path="/" element={<CamRooms />} />
+          <Route path="/cam" element={<Cam />} />
         </Routes>
       </RecoilRoot>
     </Router>

--- a/frontend/src/components/Cam/ButtonBar.tsx
+++ b/frontend/src/components/Cam/ButtonBar.tsx
@@ -89,6 +89,10 @@ function ButtonBar(): JSX.Element {
     }));
   };
 
+  const handleExit = () => {
+    window.location.href = '/';
+  };
+
   return (
     <Container isMouseOnCamPage={isMouseOnCamPage}>
       <ButtonContainer>
@@ -129,7 +133,7 @@ function ButtonBar(): JSX.Element {
       </ButtonContainer>
       <ButtonContainer>
         <Button color="red">
-          <ExitIcon />
+          <ExitIcon onClick={handleExit} />
           <span>나가기</span>
         </Button>
       </ButtonContainer>

--- a/frontend/src/components/Cam/NickNameForm.tsx
+++ b/frontend/src/components/Cam/NickNameForm.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import styled from 'styled-components';
+import { UserInfo } from '../../types/cam';
+
+const Container = styled.div`
+  width: 100vw;
+  height: 100vh;
+  background-color: #009b9f;
+
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+`;
+
+const Form = styled.form`
+  width: 30%;
+  height: 30%;
+  border-radius: 20px;
+  padding: 20px 0;
+  margin: 30px 0;
+
+  border: 2px solid #12cdd1;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-around;
+  align-items: center;
+`;
+
+const Input = styled.input`
+  border: none;
+  outline: none;
+  padding: 8px 10px;
+  margin-top: 10px;
+  border-radius: 10px;
+`;
+
+const SubmitButton = styled.button`
+  width: 60%;
+  margin-top: 15px;
+  height: 35px;
+  background: none;
+
+  border: 0;
+  outline: 0;
+
+  border-radius: 10px;
+  border: 2px solid #12cdd1;
+  cursor: pointer;
+  text-align: center;
+  transition: all 0.3s;
+
+  &:hover {
+    background-color: #12cdd1;
+    transition: all 0.3s;
+  }
+
+  a {
+    text-decoration: none;
+  }
+`;
+
+type NickNameFormProps = {
+  setUserInfo: React.Dispatch<React.SetStateAction<UserInfo>>;
+};
+
+function NickNameForm(props: NickNameFormProps): JSX.Element {
+  const { setUserInfo } = props;
+
+  const onSubmitNicknameForm = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const { currentTarget } = e;
+    const nickname = new FormData(currentTarget).get('nickname')?.toString().trim();
+    if (!nickname) {
+      return;
+    }
+    setUserInfo((prev) => ({ ...prev, nickname }));
+  };
+
+  return (
+    <Container>
+      <Form onSubmit={onSubmitNicknameForm}>
+        <Input name="nickname" placeholder="닉네임을 입력해주세요" required />
+        <SubmitButton type="submit">입력</SubmitButton>
+      </Form>
+    </Container>
+  );
+}
+
+export default NickNameForm;

--- a/frontend/src/components/Main/CamRooms.tsx
+++ b/frontend/src/components/Main/CamRooms.tsx
@@ -2,51 +2,57 @@ import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 
 import { useNavigate } from 'react-router-dom';
-import { Status, UserInfo } from '../../types/cam';
+import { Status } from '../../types/cam';
 
 const Container = styled.div`
   width: 100vw;
   height: 100vh;
-  background-color: #c4c4c4;
+  background-color: #009b9f;
 
   display: flex;
-  flex-direction: column;
   justify-content: space-around;
   align-items: center;
 `;
 
 const MainBox = styled.div`
-  min-width: 700px;
-  min-height: 600px;
-  background-color: skyblue;
+  min-width: 600px;
+  min-height: 450px;
+  width: 50%;
+  height: 50%;
+  border: 2px solid #12cdd1;
   border-radius: 20px;
 
   display: flex;
-  flex-direction: row;
-  justify-content: space-around;
+  flex-direction: column;
   align-items: center;
 `;
 
 const ListDiv = styled.div`
-  width: 33%;
   display: flex;
-  flex-direction: column;
-  justify-content: flex-start;
-  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
 `;
 
 const RoomDiv = styled.div`
-  background-color: #4ddddf;
+  width: 200px;
   padding: 10px 15px;
+  border: 2px solid #12cdd1;
   border-radius: 10px;
-  margin-top: 10px;
+  margin: 10px;
+  cursor: pointer;
+
+  &:hover {
+    background-color: #12cdd1;
+    transition: all 0.3s;
+  }
 `;
 
 const Form = styled.form`
-  width: 33%;
+  width: 50%;
   height: 45%;
-  background-color: skyblue;
   border-radius: 20px;
+  padding: 20px 0;
+  margin: 30px 0;
 
   display: flex;
   flex-direction: column;
@@ -58,22 +64,14 @@ const BoxTag = styled.span`
   font-size: 25px;
 `;
 
-const BoxMessage = styled.span`
-  font-size: 15px;
-`;
-
 const InputDiv = styled.div`
   width: 60%;
   display: flex;
   flex-direction: column;
-  justify-content: flex-start;
+  align-items: center;
   &:last-child {
     margin-top: 15px;
   }
-`;
-
-const InputTag = styled.span`
-  width: 100%;
 `;
 
 const Input = styled.input`
@@ -81,7 +79,6 @@ const Input = styled.input`
   outline: none;
   padding: 8px 10px;
   margin-top: 10px;
-
   border-radius: 10px;
 `;
 
@@ -89,19 +86,19 @@ const SubmitButton = styled.button`
   width: 60%;
   margin-top: 15px;
   height: 35px;
-  background-color: #4ddddf;
+  background: none;
 
   border: 0;
   outline: 0;
 
   border-radius: 10px;
+  border: 2px solid #12cdd1;
   cursor: pointer;
   text-align: center;
-  box-shadow: 5px 3px 3px #7c7b7b;
   transition: all 0.3s;
 
   &:hover {
-    background-color: #26f5f8;
+    background-color: #12cdd1;
     transition: all 0.3s;
   }
 
@@ -110,39 +107,22 @@ const SubmitButton = styled.button`
   }
 `;
 
-type CamRoomsProps = {
-  userInfo: UserInfo;
-  setUserInfo: React.Dispatch<React.SetStateAction<UserInfo>>;
-};
-
 type MapInfo = {
   userId: string;
   status: Status;
 };
 
-function CamRooms(props: CamRoomsProps): JSX.Element {
-  const { userInfo, setUserInfo } = props;
+function CamRooms(): JSX.Element {
   const [roomList, setRoomList] = useState<JSX.Element>();
   const navigate = useNavigate();
 
-  const getUserInfoFromForm = (e: React.FormEvent<HTMLFormElement>): UserInfo => {
-    const { currentTarget } = e;
-    const formData: FormData = new FormData(currentTarget);
-    const receivedData: UserInfo = { nickname: null, roomId: null };
-    formData.forEach((val, key) => {
-      if (key === 'nickname') receivedData.nickname = val.toString().trim();
-      if (key === 'roomid') receivedData.roomId = val.toString();
-    });
-    return receivedData;
-  };
-
   const onSumbitCreateForm = async (e: React.FormEvent<HTMLFormElement>): Promise<void> => {
     e.preventDefault();
-    const receivedData: UserInfo = getUserInfoFromForm(e);
-    const { nickname, roomId } = receivedData;
-    if (!nickname || !roomId) return;
+    const roomId = new FormData(e.currentTarget).get('roomid')?.toString().trim();
+    if (!roomId) {
+      return;
+    }
 
-    setUserInfo(receivedData);
     const response = await fetch('/api/cam/room/', {
       method: 'POST',
       headers: {
@@ -158,21 +138,10 @@ function CamRooms(props: CamRoomsProps): JSX.Element {
     else if (statusCode === 500) alert('이미 존재하는 방 입니다.');
   };
 
-  const onSumbitNicknameForm = (e: React.FormEvent<HTMLFormElement>): void => {
-    e.preventDefault();
-    const receivedData: UserInfo = getUserInfoFromForm(e);
-
-    setUserInfo(receivedData);
-  };
-
   const onClickRoomDiv = (e: React.MouseEvent<HTMLDivElement>): void => {
-    // eslint-disable-next-line no-alert
-    if (!userInfo.nickname) alert('닉네임을 먼저 설정해주세요!');
-    else {
-      const { currentTarget } = e;
-      const roomId = currentTarget.dataset.id;
-      navigate(`/cam?roomid=${roomId}`);
-    }
+    const { currentTarget } = e;
+    const roomId = currentTarget.dataset.id;
+    navigate(`/cam?roomid=${roomId}`);
   };
 
   const buildRoomList = async (): Promise<void> => {
@@ -201,33 +170,15 @@ function CamRooms(props: CamRoomsProps): JSX.Element {
     buildRoomList();
   }, []);
 
-  useEffect(() => {
-    buildRoomList();
-  }, [userInfo]);
-
   return (
     <Container>
       <MainBox>
         <Form onSubmit={onSumbitCreateForm}>
           <BoxTag>Create Room</BoxTag>
           <InputDiv>
-            <InputTag>Nickname</InputTag>
-            <Input name="nickname" placeholder="닉네임을 입력하세요" required />
-          </InputDiv>
-          <InputDiv>
-            <InputTag>Room Number</InputTag>
-            <Input name="roomid" placeholder="방 번호를 입력하세요" required />
+            <Input name="roomid" placeholder="방 이름을 입력하세요" required />
           </InputDiv>
           <SubmitButton type="submit">Create</SubmitButton>
-        </Form>
-        <Form onSubmit={onSumbitNicknameForm}>
-          <BoxTag> Set Nickname</BoxTag>
-          <BoxMessage> Current Nickname : {userInfo?.nickname || 'None'}</BoxMessage>
-          <InputDiv>
-            <InputTag>Nickname</InputTag>
-            <Input name="nickname" placeholder="닉네임을 입력하세요" required />
-          </InputDiv>
-          <SubmitButton type="submit">닉네임 설정</SubmitButton>
         </Form>
         <ListDiv>{roomList}</ListDiv>
       </MainBox>


### PR DESCRIPTION
- 메인 페이지에 아직 쓰지 않는 기능들을 제외하고, 방 생성과 참여 기능만을 남겨두었습니다.
- 닉네임이 존재하는지 여부를 Cam component에서 체크하도록 변경하였습니다.
- 이제 Cam이 랜더링 된 상태에서 닉네임이 없을 경우 닉네임 입력 컴포넌트가 출력됩니다.
- 간단한 css 스타일들을 적용했습니다.

![image](https://user-images.githubusercontent.com/76931330/141325710-b6e0fc01-298c-42e1-9794-7f539989ff84.png)
![image](https://user-images.githubusercontent.com/76931330/141325762-7587e21a-14b5-4065-8ee0-e78214eef83b.png)
