### PR TITLE
Cam 트랜지션 관련 최적화, 화면 공유 시 사용자 목록 켜지는 기능 추가

### DIFF
--- a/frontend/src/assets/icons/background.svg
+++ b/frontend/src/assets/icons/background.svg
@@ -1,3 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
-  <path fill-rule="evenodd" d="M4 3a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V5a2 2 0 00-2-2H4zm12 12H4l4-8 3 6 2-4 3 6z" clip-rule="evenodd" />
-</svg>

--- a/frontend/src/components/Cam/ButtonBar.tsx
+++ b/frontend/src/components/Cam/ButtonBar.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from 'react';
+import React, { RefObject, useContext, useEffect, useState } from 'react';
 import styled from 'styled-components';
 
 import { ReactComponent as MicIcon } from '../../assets/icons/mic.svg';
@@ -25,13 +25,15 @@ const Container = styled.div<{ isMouseOnCamPage: boolean }>`
   height: 8vh;
   margin-top: 5px;
 
-  display: ${(props) => (props.isMouseOnCamPage ? 'flex' : 'none')};
+  display: flex;
   flex-direction: row;
   justify-content: space-between;
   align-items: center;
 
   border-radius: 10px;
-  transition: all 0.5s ease;
+  transition: bottom 0.5s ease;
+  position: absolute;
+  bottom: ${(props) => (props.isMouseOnCamPage ? '0' : '-8vh')};
 `;
 
 const ButtonContainer = styled.div`
@@ -63,10 +65,17 @@ const Button = styled.div<{ color?: string }>`
   }
 `;
 
-function ButtonBar(): JSX.Element {
+type ButtonBarProps = {
+  camRef: RefObject<HTMLDivElement> | null;
+};
+
+function ButtonBar(props: ButtonBarProps): JSX.Element {
+  const { camRef } = props;
+
+  const [isMouseOnCamPage, setMouseOnCamPage] = useState<boolean>(true);
   const [isActiveNicknameModal, setIsActiveNicknameModal] = useState<boolean>(false);
   const { localStream, setLocalStatus, localStatus, setUserInfo } = useContext(CamStoreContext);
-  const { handleUserListTabActive, handleChattingTabActive, isMouseOnCamPage } = useContext(ToggleStoreContext);
+  const { handleUserListTabActive, handleChattingTabActive } = useContext(ToggleStoreContext);
   const { toggleSTTActive, isSTTActive } = useContext(STTStoreContext);
 
   const { handleScreenShareActive } = useContext(SharedScreenStoreContext);
@@ -100,6 +109,21 @@ function ButtonBar(): JSX.Element {
   const handleExit = () => {
     window.location.href = '/';
   };
+
+  const handleMouseOverCamPage = (): void => {
+    setMouseOnCamPage(true);
+  };
+
+  const handleMouseLeaveCamPage = (): void => {
+    setMouseOnCamPage(false);
+  };
+
+  useEffect(() => {
+    if (camRef?.current) {
+      camRef.current.onmouseover = handleMouseOverCamPage;
+      camRef.current.onmouseleave = handleMouseLeaveCamPage;
+    }
+  }, []);
 
   return (
     <>

--- a/frontend/src/components/Cam/ButtonBar.tsx
+++ b/frontend/src/components/Cam/ButtonBar.tsx
@@ -9,7 +9,6 @@ import { ReactComponent as IdentificationIcon } from '../../assets/icons/identif
 import { ReactComponent as ChatIcon } from '../../assets/icons/chat.svg';
 import { ReactComponent as PresenstationIcon } from '../../assets/icons/presentation.svg';
 import { ReactComponent as UsersIcon } from '../../assets/icons/users.svg';
-import { ReactComponent as BackgroundIcon } from '../../assets/icons/background.svg';
 import { ReactComponent as ExitIcon } from '../../assets/icons/exit.svg';
 import { ReactComponent as STTIcon } from '../../assets/icons/speech.svg';
 import { ReactComponent as STTDisabledIcon } from '../../assets/icons/speech-disabled.svg';
@@ -146,17 +145,13 @@ function ButtonBar(props: ButtonBarProps): JSX.Element {
             <IdentificationIcon />
             <span>닉네임</span>
           </Button>
-          <Button>
-            <BackgroundIcon />
-            <span>가상 배경</span>
+          <Button onClick={handleUserListTabActive}>
+            <UsersIcon />
+            <span>사용자 목록</span>
           </Button>
           <Button color="#00ff2e" onClick={handleScreenShareActive}>
             <PresenstationIcon />
             <span>화면 공유</span>
-          </Button>
-          <Button onClick={handleUserListTabActive}>
-            <UsersIcon />
-            <span>사용자 목록</span>
           </Button>
           <Button onClick={handleChattingTabActive}>
             <ChatIcon />

--- a/frontend/src/components/Cam/Cam.tsx
+++ b/frontend/src/components/Cam/Cam.tsx
@@ -57,7 +57,7 @@ function Cam(): JSX.Element {
         <NickNameForm setUserInfo={setUserInfo} />
       ) : (
         <CamStore userInfo={userInfo} setUserInfo={setUserInfo}>
-          <ToggleStore camRef={camRef}>
+          <ToggleStore>
             <STTStore>
               <SharedScreenStore>
                 <UpperTab>
@@ -65,7 +65,7 @@ function Cam(): JSX.Element {
                   <UserListTab />
                   <ChattingTab />
                 </UpperTab>
-                <ButtonBar />
+                <ButtonBar camRef={camRef} />
               </SharedScreenStore>
             </STTStore>
           </ToggleStore>

--- a/frontend/src/components/Cam/ChattingTab.tsx
+++ b/frontend/src/components/Cam/ChattingTab.tsx
@@ -9,7 +9,7 @@ import { CamStoreContext } from './CamStore';
 
 const Container = styled.div<{ isActive: boolean; isMouseOnCamPage: boolean }>`
   width: 27vw;
-  height: ${(props) => (props.isMouseOnCamPage ? '90vh' : '98vh')};
+  height: 90vh;
   background-color: #ffffff;
   display: flex;
   ${(props) =>

--- a/frontend/src/components/Cam/ChattingTab.tsx
+++ b/frontend/src/components/Cam/ChattingTab.tsx
@@ -11,10 +11,11 @@ const Container = styled.div<{ isActive: boolean; isMouseOnCamPage: boolean }>`
   height: 90vh;
   background-color: #ffffff;
   display: flex;
-  transition: right 0.5s;
+  transition: right 0.5s, opacity 0.5s;
   position: absolute;
   width: 27vw;
   right: ${(props) => (props.isActive ? '0' : '-30vw')};
+  opacity: ${(props) => (props.isActive ? '1' : '0')};
 
   flex-direction: column;
   justify-content: space-around;
@@ -232,7 +233,6 @@ function ChattingTab(): JSX.Element {
     <Container isActive={isChattingTabActive} isMouseOnCamPage={isMouseOnCamPage}>
       <ChatLogs ref={chatLogsRef}>{currentChatLogs}</ChatLogs>
       <TextContainer>
-        {' '}
         <STTScreen sendMessage={sendMessage} />
         <ChatTextarea placeholder="내용을 입력하세요." onKeyDown={handleKeyDown} />
       </TextContainer>

--- a/frontend/src/components/Cam/ChattingTab.tsx
+++ b/frontend/src/components/Cam/ChattingTab.tsx
@@ -8,23 +8,13 @@ import { ToggleStoreContext } from './ToggleStore';
 import { CamStoreContext } from './CamStore';
 
 const Container = styled.div<{ isActive: boolean; isMouseOnCamPage: boolean }>`
-  width: 27vw;
   height: 90vh;
   background-color: #ffffff;
   display: flex;
-  ${(props) =>
-    props.isActive
-      ? `
-    position: relative;
-    transition: all 0.5s;
-  `
-      : ` 
-      opacity:0;
-      visibility:hidden;
-      position: absolute;
-      right:0px;
-      transition: opacity 0.5s, visibility 0.5s;
-      `};
+  transition: right 0.5s;
+  position: absolute;
+  width: 27vw;
+  right: ${(props) => (props.isActive ? '0' : '-30vw')};
 
   flex-direction: column;
   justify-content: space-around;

--- a/frontend/src/components/Cam/MainScreen.tsx
+++ b/frontend/src/components/Cam/MainScreen.tsx
@@ -9,9 +9,9 @@ import LocalUserScreen from './LocalUserScreen';
 import UserScreen from './UserScreen';
 import { SharedScreenStoreContext } from './SharedScreen/SharedScreenStore';
 
-const Container = styled.div<{ activeTab: string[]; isMouseOnCamPage: boolean; numOfScreen: number }>`
+const Container = styled.div<{ activeTab: string[]; numOfScreen: number }>`
   width: ${(props) => props.activeTab[0]};
-  height: ${(props) => (props.isMouseOnCamPage ? '90vh' : '98vh')};
+  height: 90vh;
   background-color: black;
   display: grid;
   grid-template-columns: repeat(${(props) => Math.ceil(props.numOfScreen ** 0.5)}, minmax(30%, auto));
@@ -24,7 +24,7 @@ const Container = styled.div<{ activeTab: string[]; isMouseOnCamPage: boolean; n
 
 function MainScreen(): JSX.Element {
   const { screenList } = useContext(CamStoreContext);
-  const { isChattingTabActive, isMouseOnCamPage } = useContext(ToggleStoreContext);
+  const { isChattingTabActive } = useContext(ToggleStoreContext);
   const { sharedScreen } = useContext(SharedScreenStoreContext);
 
   const countActiveTab = (): string[] => {
@@ -38,24 +38,14 @@ function MainScreen(): JSX.Element {
 
   if (sharedScreen !== null) {
     return (
-      <Container
-        activeTab={countActiveTab()}
-        onAnimationEnd={handleAnimationEnd}
-        isMouseOnCamPage={isMouseOnCamPage}
-        numOfScreen={1}
-      >
+      <Container activeTab={countActiveTab()} onAnimationEnd={handleAnimationEnd} numOfScreen={1}>
         <SharedScreen stream={sharedScreen} />
       </Container>
     );
   }
 
   return (
-    <Container
-      activeTab={countActiveTab()}
-      onAnimationEnd={handleAnimationEnd}
-      isMouseOnCamPage={isMouseOnCamPage}
-      numOfScreen={screenList.length + 1}
-    >
+    <Container activeTab={countActiveTab()} onAnimationEnd={handleAnimationEnd} numOfScreen={screenList.length + 1}>
       <LocalUserScreen />
       {screenList.map((screen: Screen) => (
         <UserScreen key={screen.userId} stream={screen.stream} userId={screen.userId} />

--- a/frontend/src/components/Cam/SharedScreen/SharedScreenStore.tsx
+++ b/frontend/src/components/Cam/SharedScreen/SharedScreenStore.tsx
@@ -1,9 +1,10 @@
-import React, { createContext, useEffect, useRef, useState } from 'react';
+import React, { createContext, useContext, useEffect, useRef, useState } from 'react';
 import { useRecoilValue } from 'recoil';
 
 import SharedScreenReceiver from './SharedScreenReceiver';
 import SocketState from '../../../atoms/socket';
 import SharedScreenSender from './SharedScreenSender';
+import { ToggleStoreContext } from '../ToggleStore';
 
 type SharedScreenStoreProps = {
   children: React.ReactChild[] | React.ReactChild;
@@ -20,6 +21,8 @@ function SharedScreenStore(props: SharedScreenStoreProps): JSX.Element {
 
   const sharedScreenReceiverRef = useRef<SharedScreenReceiver>();
   const sharedScreenSenderRef = useRef<SharedScreenSender>();
+
+  const { setUserListTabActive } = useContext(ToggleStoreContext);
 
   const currentURL = new URL(window.location.href);
   const roomId = currentURL.searchParams.get('roomid');
@@ -64,6 +67,12 @@ function SharedScreenStore(props: SharedScreenStoreProps): JSX.Element {
       sharedScreenSenderRef.current = undefined;
     }
   };
+
+  useEffect(() => {
+    if (sharedScreen) {
+      setUserListTabActive(true);
+    }
+  }, [sharedScreen]);
 
   return (
     <SharedScreenStoreContext.Provider value={{ sharedScreen, setSharedScreen, handleScreenShareActive }}>

--- a/frontend/src/components/Cam/ToggleStore.tsx
+++ b/frontend/src/components/Cam/ToggleStore.tsx
@@ -25,6 +25,7 @@ function ToggleStore(props: CamToggleStoreProps): JSX.Element {
       value={{
         isUserListTabActive,
         isChattingTabActive,
+        setUserListTabActive,
         handleUserListTabActive,
         handleChattingTabActive,
       }}

--- a/frontend/src/components/Cam/ToggleStore.tsx
+++ b/frontend/src/components/Cam/ToggleStore.tsx
@@ -1,16 +1,14 @@
-import { createContext, RefObject, useEffect, useState } from 'react';
+import { createContext, useState } from 'react';
 
 export const ToggleStoreContext = createContext<React.ComponentState>(null);
 
 type CamToggleStoreProps = {
   children: React.ReactChild[] | React.ReactChild;
-  camRef: RefObject<HTMLDivElement> | null;
 };
 
 function ToggleStore(props: CamToggleStoreProps): JSX.Element {
-  const { children, camRef } = props;
+  const { children } = props;
 
-  const [isMouseOnCamPage, setMouseOnCamPage] = useState<boolean>(true);
   const [isUserListTabActive, setUserListTabActive] = useState<boolean>(false);
   const [isChattingTabActive, setChattingTabActive] = useState<boolean>(true);
 
@@ -22,31 +20,13 @@ function ToggleStore(props: CamToggleStoreProps): JSX.Element {
     setChattingTabActive(!isChattingTabActive);
   };
 
-  const handleMouseOverCamPage = (): void => {
-    setMouseOnCamPage(true);
-  };
-
-  const handleMouseLeaveCamPage = (): void => {
-    setMouseOnCamPage(false);
-  };
-
-  useEffect(() => {
-    if (camRef?.current) {
-      camRef.current.onmouseover = handleMouseOverCamPage;
-      camRef.current.onmouseleave = handleMouseLeaveCamPage;
-    }
-  }, []);
-
   return (
     <ToggleStoreContext.Provider
       value={{
         isUserListTabActive,
         isChattingTabActive,
-        isMouseOnCamPage,
         handleUserListTabActive,
         handleChattingTabActive,
-        handleMouseOverCamPage,
-        handleMouseLeaveCamPage,
       }}
     >
       {children}

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -8,6 +8,7 @@ const GlobalStyle = createGlobalStyle`
   body {
     margin: 0;
     padding: 0;
+    overflow: hidden;
   }
 `;
 


### PR DESCRIPTION
기존에 isMouseOnScreen 때문에 마우스를 빠르게 왔다갔다 할 경우 MainScreen의 깜빡임 현상이 심했습니다. 그것을 해결하기 위해 state를 다른 곳으로 분리했고, 하다보니 이것저것 고치고 싶은게 생겨서 제 맘대로 건드려 봤습니다~