### PR TITLE
깃허브 로그인 구현 (세션 없음)

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -27,6 +27,9 @@ lerna-debug.log*
 .settings/
 *.sublime-workspace
 
+# .env
+.env.github
+
 # IDE - VSCode
 .vscode/*
 !.vscode/settings.json

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -16,6 +16,7 @@
         "@nestjs/platform-socket.io": "^8.1.2",
         "@nestjs/typeorm": "^8.0.2",
         "@nestjs/websockets": "^8.1.2",
+        "axios": "^0.24.0",
         "mysql2": "^2.3.3",
         "peer": "^0.6.1",
         "reflect-metadata": "^0.1.13",
@@ -1500,6 +1501,14 @@
         }
       }
     },
+    "node_modules/@nestjs/common/node_modules/axios": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.23.0.tgz",
+      "integrity": "sha512-NmvAE4i0YAv5cKq8zlDoPd1VLKAqX5oLuZKs8xkJa4qi6RGn0uhCYFjWtHHC9EM/MwOwYWOs53W+V0aqEXq1sg==",
+      "dependencies": {
+        "follow-redirects": "^1.14.4"
+      }
+    },
     "node_modules/@nestjs/config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@nestjs/config/-/config-1.1.0.tgz",
@@ -2650,9 +2659,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.23.0.tgz",
-      "integrity": "sha512-NmvAE4i0YAv5cKq8zlDoPd1VLKAqX5oLuZKs8xkJa4qi6RGn0uhCYFjWtHHC9EM/MwOwYWOs53W+V0aqEXq1sg==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
+      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
       "dependencies": {
         "follow-redirects": "^1.14.4"
       }
@@ -10766,6 +10775,16 @@
         "iterare": "1.2.1",
         "tslib": "2.3.1",
         "uuid": "8.3.2"
+      },
+      "dependencies": {
+        "axios": {
+          "version": "0.23.0",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.23.0.tgz",
+          "integrity": "sha512-NmvAE4i0YAv5cKq8zlDoPd1VLKAqX5oLuZKs8xkJa4qi6RGn0uhCYFjWtHHC9EM/MwOwYWOs53W+V0aqEXq1sg==",
+          "requires": {
+            "follow-redirects": "^1.14.4"
+          }
+        }
       }
     },
     "@nestjs/config": {
@@ -11665,9 +11684,9 @@
       "dev": true
     },
     "axios": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.23.0.tgz",
-      "integrity": "sha512-NmvAE4i0YAv5cKq8zlDoPd1VLKAqX5oLuZKs8xkJa4qi6RGn0uhCYFjWtHHC9EM/MwOwYWOs53W+V0aqEXq1sg==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
+      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
       "requires": {
         "follow-redirects": "^1.14.4"
       }

--- a/backend/package.json
+++ b/backend/package.json
@@ -28,6 +28,7 @@
     "@nestjs/platform-socket.io": "^8.1.2",
     "@nestjs/typeorm": "^8.0.2",
     "@nestjs/websockets": "^8.1.2",
+    "axios": "^0.24.0",
     "mysql2": "^2.3.3",
     "peer": "^0.6.1",
     "reflect-metadata": "^0.1.13",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -13,10 +13,14 @@ import { MessageModule } from './message/message.module';
 import { EmoticonModule } from './emoticon/emoticon.module';
 import { ServerModule } from './server/server.module';
 import { CamsModule } from './cams/cams.module';
+import { LoginModule } from './login/login.module';
+import githubConfig from './config/github.config';
 
 @Module({
   imports: [
     ConfigModule.forRoot({
+      load: [githubConfig],
+      envFilePath: ['.env', '.env.github'],
       isGlobal: true,
     }),
     TypeOrmModule.forRoot(ormConfig()),

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -32,6 +32,7 @@ import githubConfig from './config/github.config';
     EmoticonModule,
     ServerModule,
     CamsModule,
+    LoginModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/config/github.config.ts
+++ b/backend/src/config/github.config.ts
@@ -1,0 +1,16 @@
+import { registerAs } from '@nestjs/config';
+
+interface GitHubConfig {
+  clientID: string;
+  clientSecret: string;
+  callbackURL: string;
+}
+
+export default registerAs(
+  'github',
+  (): GitHubConfig => ({
+    clientID: process.env.GITHUB_CLIENT_ID,
+    clientSecret: process.env.GITHUB_CLIENT_SECRET,
+    callbackURL: process.env.GITHUB_CALLBACK_URL,
+  }),
+);

--- a/backend/src/login/login.controller.spec.ts
+++ b/backend/src/login/login.controller.spec.ts
@@ -1,9 +1,13 @@
+import { Repository } from 'typeorm';
 import { LoginController } from './login.controller';
 import { LoginService } from './login.service';
+
+import { User } from '../user/user.entity';
 
 describe('LoginController', () => {
   let controller: LoginController;
   let service: LoginService;
+  let repository: Repository<User>;
 
   beforeEach(async () => {
     const githubConfig = {
@@ -11,7 +15,8 @@ describe('LoginController', () => {
       clientSecret: 'string',
       callbackURL: 'string',
     };
-    service = new LoginService(githubConfig);
+    repository = null;
+    service = new LoginService(githubConfig, repository);
     controller = new LoginController(service);
   });
 

--- a/backend/src/login/login.controller.spec.ts
+++ b/backend/src/login/login.controller.spec.ts
@@ -1,0 +1,21 @@
+import { LoginController } from './login.controller';
+import { LoginService } from './login.service';
+
+describe('LoginController', () => {
+  let controller: LoginController;
+  let service: LoginService;
+
+  beforeEach(async () => {
+    const githubConfig = {
+      clientID: 'string',
+      clientSecret: 'string',
+      callbackURL: 'string',
+    };
+    service = new LoginService(githubConfig);
+    controller = new LoginController(service);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/backend/src/login/login.controller.ts
+++ b/backend/src/login/login.controller.ts
@@ -1,0 +1,11 @@
+import { Controller, Get, Query } from '@nestjs/common';
+import { LoginService } from './login.service';
+
+@Controller('/api/login')
+export class LoginController {
+  constructor(private loginService: LoginService) {}
+  @Get('/github')
+  async githubLogin(@Query('code') code: string) {
+    return await this.loginService.githubLogin(code);
+  }
+}

--- a/backend/src/login/login.module.ts
+++ b/backend/src/login/login.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { LoginService } from './login.service';
+
+@Module({
+  imports: [ConfigModule],
+  providers: [LoginService],
+})
+export class LoginModule {}

--- a/backend/src/login/login.module.ts
+++ b/backend/src/login/login.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
-import { UserModule } from 'src/user/user.module';
+
+import { UserModule } from '../user/user.module';
 import { LoginController } from './login.controller';
 import { LoginService } from './login.service';
 

--- a/backend/src/login/login.module.ts
+++ b/backend/src/login/login.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
+import { UserModule } from 'src/user/user.module';
 import { LoginController } from './login.controller';
 import { LoginService } from './login.service';
 
 @Module({
-  imports: [ConfigModule],
+  imports: [ConfigModule, UserModule],
   controllers: [LoginController],
   providers: [LoginService],
 })

--- a/backend/src/login/login.module.ts
+++ b/backend/src/login/login.module.ts
@@ -1,9 +1,11 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
+import { LoginController } from './login.controller';
 import { LoginService } from './login.service';
 
 @Module({
   imports: [ConfigModule],
+  controllers: [LoginController],
   providers: [LoginService],
 })
 export class LoginModule {}

--- a/backend/src/login/login.service.spec.ts
+++ b/backend/src/login/login.service.spec.ts
@@ -1,6 +1,3 @@
-import { ConfigModule } from '@nestjs/config';
-import { Test, TestingModule } from '@nestjs/testing';
-import githubConfig from '../config/github.config';
 import { LoginService } from './login.service';
 
 describe('LoginService', () => {

--- a/backend/src/login/login.service.spec.ts
+++ b/backend/src/login/login.service.spec.ts
@@ -1,7 +1,10 @@
+import { User } from '../user/user.entity';
+import { Repository } from 'typeorm';
 import { LoginService } from './login.service';
 
 describe('LoginService', () => {
   let service: LoginService;
+  let userRepository: Repository<User>;
 
   beforeEach(async () => {
     const githubConfig = {
@@ -9,8 +12,8 @@ describe('LoginService', () => {
       clientSecret: 'string',
       callbackURL: 'string',
     };
-
-    service = new LoginService(githubConfig);
+    userRepository = null;
+    service = new LoginService(githubConfig, userRepository);
   });
 
   it('should be defined', () => {

--- a/backend/src/login/login.service.spec.ts
+++ b/backend/src/login/login.service.spec.ts
@@ -1,0 +1,22 @@
+import { ConfigModule } from '@nestjs/config';
+import { Test, TestingModule } from '@nestjs/testing';
+import githubConfig from '../config/github.config';
+import { LoginService } from './login.service';
+
+describe('LoginService', () => {
+  let service: LoginService;
+
+  beforeEach(async () => {
+    const githubConfig = {
+      clientID: 'string',
+      clientSecret: 'string',
+      callbackURL: 'string',
+    };
+
+    service = new LoginService(githubConfig);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/backend/src/login/login.service.ts
+++ b/backend/src/login/login.service.ts
@@ -1,5 +1,15 @@
-import { Inject, Injectable } from '@nestjs/common';
+import {
+  HttpException,
+  Inject,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import { ConfigType } from '@nestjs/config';
+import { InjectRepository } from '@nestjs/typeorm';
+import axios from 'axios';
+import { Repository } from 'typeorm';
+
+import { User } from '../user/user.entity';
 
 import githubConfig from '../config/github.config';
 
@@ -7,8 +17,44 @@ import githubConfig from '../config/github.config';
 export class LoginService {
   constructor(
     @Inject(githubConfig.KEY) private config: ConfigType<typeof githubConfig>,
+    @InjectRepository(User) private userRepository: Repository<User>,
   ) {}
-  async githubLogin(code: string) {
-    console.log(this.config);
+  async githubLogin(code: string): Promise<User> {
+    try {
+      const accessTokenResponse = await axios.post(
+        'https://github.com/login/oauth/access_token',
+        {
+          client_id: this.config.clientID,
+          client_secret: this.config.clientSecret,
+          redirect_uri: this.config.callbackURL,
+          code,
+        },
+        {
+          headers: { Accept: 'application/json' },
+        },
+      );
+      const { access_token: accessToken } = accessTokenResponse.data;
+      const githubUserResponse = await axios.get(
+        'https://api.github.com/user',
+        {
+          headers: { Authorization: `token ${accessToken}` },
+        },
+      );
+
+      const { id: githubId, avator_url } = githubUserResponse.data;
+      const user = await this.userRepository.findOne({ where: { githubId } });
+
+      if (!user) {
+        throw new NotFoundException();
+      }
+
+      return user;
+    } catch (error) {
+      if (error instanceof NotFoundException) {
+        throw error;
+      }
+
+      throw new HttpException('bad request', 400);
+    }
   }
 }

--- a/backend/src/login/login.service.ts
+++ b/backend/src/login/login.service.ts
@@ -1,0 +1,14 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { ConfigType } from '@nestjs/config';
+
+import githubConfig from '../config/github.config';
+
+@Injectable()
+export class LoginService {
+  constructor(
+    @Inject(githubConfig.KEY) private config: ConfigType<typeof githubConfig>,
+  ) {}
+  async githubLogin(code: string) {
+    console.log(this.config);
+  }
+}

--- a/backend/src/server/server.entity.ts
+++ b/backend/src/server/server.entity.ts
@@ -5,7 +5,7 @@ import {
   ManyToOne,
   JoinColumn,
 } from 'typeorm';
-import { User } from 'src/user/user.entity';
+import { User } from '../user/user.entity';
 
 @Entity()
 export class Server {

--- a/backend/src/user/user.module.ts
+++ b/backend/src/user/user.module.ts
@@ -5,7 +5,8 @@ import { User } from './user.entity';
 
 @Module({
   imports: [TypeOrmModule.forFeature([User, Server])],
-  providers: [],
   controllers: [],
+  providers: [],
+  exports: [TypeOrmModule],
 })
 export class UserModule {}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
 
 import Cam from './components/Cam/Cam';
 import CamRooms from './components/Main/CamRooms';
+import LoginMain from './components/LoginPage/LoginMain';
 
 function App(): JSX.Element {
   return (
@@ -11,6 +12,7 @@ function App(): JSX.Element {
       <RecoilRoot>
         <Routes>
           <Route path="/" element={<CamRooms />} />
+          <Route path="/login" element={<LoginMain />} />
           <Route path="/cam" element={<Cam />} />
         </Routes>
       </RecoilRoot>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,7 +14,7 @@ function App(): JSX.Element {
         <Routes>
           <Route path="/" element={<CamRooms />} />
           <Route path="/login" element={<LoginMain />} />
-          <Route path="/login/github" element={<LoginCallback />} />
+          <Route path="/login/github" element={<LoginCallback service="github" />} />
           <Route path="/cam" element={<Cam />} />
         </Routes>
       </RecoilRoot>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
 import Cam from './components/Cam/Cam';
 import CamRooms from './components/Main/CamRooms';
 import LoginMain from './components/LoginPage/LoginMain';
+import LoginCallback from './components/LoginPage/LoginCallback';
 
 function App(): JSX.Element {
   return (
@@ -13,6 +14,7 @@ function App(): JSX.Element {
         <Routes>
           <Route path="/" element={<CamRooms />} />
           <Route path="/login" element={<LoginMain />} />
+          <Route path="/login/github" element={<LoginCallback />} />
           <Route path="/cam" element={<Cam />} />
         </Routes>
       </RecoilRoot>

--- a/frontend/src/atoms/user.ts
+++ b/frontend/src/atoms/user.ts
@@ -1,0 +1,9 @@
+import { atom } from 'recoil';
+import User from '../types/user';
+
+const userState = atom<User | null>({
+  key: 'user',
+  default: null,
+});
+
+export default userState;

--- a/frontend/src/components/LoginPage/LoginCallback.tsx
+++ b/frontend/src/components/LoginPage/LoginCallback.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const Container = styled.div``;
+
+function LoginCallback(): JSX.Element {
+  return (
+    <Container>
+      <div>로그인 중...</div>
+    </Container>
+  );
+}
+
+export default LoginCallback;

--- a/frontend/src/components/LoginPage/LoginCallback.tsx
+++ b/frontend/src/components/LoginPage/LoginCallback.tsx
@@ -1,14 +1,80 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { Navigate } from 'react-router-dom';
+import { useRecoilState } from 'recoil';
 import styled from 'styled-components';
+import userState from '../../atoms/user';
+
+import User from '../../types/user';
 
 const Container = styled.div``;
 
-function LoginCallback(): JSX.Element {
-  return (
-    <Container>
-      <div>로그인 중...</div>
-    </Container>
-  );
+const requestLogin = async (code: string, service: string): Promise<User> => {
+  const response = await fetch(`/api/login/${service}?code=${code}`);
+  if (!response.ok) {
+    throw new Error(`${response.status}`);
+  }
+  const user: User = await response.json();
+  return user;
+};
+
+type LoginCallbackProps = {
+  service: 'github';
+};
+
+function LoginCallback(props: LoginCallbackProps): JSX.Element {
+  const { service } = props;
+  const [loading, setLoading] = useState<boolean>(true);
+  const [isSuccess, setIsSuccess] = useState<boolean>(false);
+  const [isNewUser, setIsNewUser] = useState<boolean>(false);
+  const [loggedInUser, setLoggedInUser] = useRecoilState(userState);
+
+  const urlParams = new URLSearchParams(window.location.search);
+  const code = urlParams.get('code');
+
+  if (!code) {
+    return <Navigate to="/login" />;
+  }
+
+  useEffect(() => {
+    const tryLogin = async () => {
+      try {
+        const user = await requestLogin(code, service);
+        setLoggedInUser(user);
+        setLoading(false);
+        setIsSuccess(true);
+      } catch (e) {
+        // Go to register page
+        if (e instanceof Error && e.message === '404') {
+          setIsNewUser(true);
+        }
+        // Login Fail
+        setLoading(false);
+        setIsSuccess(false);
+      }
+    };
+
+    tryLogin();
+  }, [code]);
+
+  if (loggedInUser || isSuccess) {
+    return <Navigate to="/" />;
+  }
+
+  if (loading) {
+    return (
+      <Container>
+        <div>로그인 중...</div>
+      </Container>
+    );
+  }
+
+  if (isNewUser) {
+    // TO DO: 회원가입 페이지
+    return <Navigate to="/" />;
+  }
+
+  // Login Fail
+  return <Navigate to="/login" />;
 }
 
 export default LoginCallback;

--- a/frontend/src/components/LoginPage/OAuthLogin.tsx
+++ b/frontend/src/components/LoginPage/OAuthLogin.tsx
@@ -42,8 +42,8 @@ const OAuthLoginButton = styled.div`
 `;
 
 function OAuthLogin(): JSX.Element {
-  const CLIENT_ID = 'b0e26b0f6a8f638ba3af';
-  const REDIRECT_URL = 'http://localhost:3000/login';
+  const CLIENT_ID = '028b90a23e9500c30c28';
+  const REDIRECT_URL = 'http://localhost:3000/login/github';
 
   const onClick = () => {
     const url = `https://github.com/login/oauth/authorize?client_id=${CLIENT_ID}&redirect_uri=${REDIRECT_URL}`;

--- a/frontend/src/components/Main/CamRooms.tsx
+++ b/frontend/src/components/Main/CamRooms.tsx
@@ -1,8 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { useRecoilValue } from 'recoil';
+import { useNavigate, Link } from 'react-router-dom';
 
-import { useNavigate } from 'react-router-dom';
 import { Status } from '../../types/cam';
 import socketState from '../../atoms/socket';
 
@@ -193,6 +193,7 @@ function CamRooms(): JSX.Element {
           <SubmitButton type="submit">Create</SubmitButton>
         </Form>
         <ListDiv>{roomList}</ListDiv>
+        <Link to="/login">Login</Link>
       </MainBox>
     </Container>
   );

--- a/frontend/src/components/Main/CamRooms.tsx
+++ b/frontend/src/components/Main/CamRooms.tsx
@@ -5,6 +5,7 @@ import { useNavigate, Link } from 'react-router-dom';
 
 import { Status } from '../../types/cam';
 import socketState from '../../atoms/socket';
+import userState from '../../atoms/user';
 
 const Container = styled.div`
   width: 100vw;
@@ -117,6 +118,7 @@ type MapInfo = {
 function CamRooms(): JSX.Element {
   const socket = useRecoilValue(socketState);
   const [roomList, setRoomList] = useState<JSX.Element[]>();
+  const loggedInUser = useRecoilValue(userState);
   const navigate = useNavigate();
 
   const onSumbitCreateForm = async (e: React.FormEvent<HTMLFormElement>): Promise<void> => {
@@ -193,7 +195,7 @@ function CamRooms(): JSX.Element {
           <SubmitButton type="submit">Create</SubmitButton>
         </Form>
         <ListDiv>{roomList}</ListDiv>
-        <Link to="/login">Login</Link>
+        {loggedInUser === null ? <Link to="/login">Login</Link> : <Link to="/logout">Logout</Link>}
       </MainBox>
     </Container>
   );

--- a/frontend/src/types/user.ts
+++ b/frontend/src/types/user.ts
@@ -1,0 +1,8 @@
+type User = {
+  id: number;
+  githubId: number;
+  nickname: string;
+  profile: string;
+};
+
+export default User;


### PR DESCRIPTION
깃허브 로그인 버튼 클릭 시 로그인을 요청합니다.
깃허브에서는 callback url로 리다이렉션 응답을 보내며, 이는 frontend의 콜백 페이지에서 받아서 서버로 code를 전송합니다.
서버는 해당 code를 받아 유저 정보를 깃허브에서 가져오며, 가져온 github id를 이용하여 user DB에 접근합니다. 이때 유저가 존재하면 해당 user 값을 응답으로 보내며, frontend에서는 해당 user를 recoil의 userState로 설정합니다.

현재 세션, 회원가입 로직 등은 구현하지 않았습니다.