### PR TITLE
screen 배치 방식 변경, 기본 닉네임 구현

### DIFF
--- a/backend/src/cam/cam-inner.service.ts
+++ b/backend/src/cam/cam-inner.service.ts
@@ -1,6 +1,5 @@
-import { forwardRef, Inject, Injectable } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { Status, CamMap } from '../types/cam';
-import { CamService } from './cam.service';
 
 type RoomId = string;
 type SocketId = string;
@@ -17,10 +16,7 @@ export class CamInnerService {
   private map: Map<string, Array<CamMap>>;
   private sharedScreen: Map<RoomId, { userId: string | null }>;
 
-  constructor(
-    @Inject(forwardRef(() => CamService))
-    private readonly camService: CamService,
-  ) {
+  constructor() {
     this.map = new Map();
     this.sharedScreen = new Map();
   }
@@ -57,7 +53,6 @@ export class CamInnerService {
     const room = this.map.get(roomId).filter((user) => user.userId !== userId);
     if (room.length == 0) {
       this.map.delete(roomId);
-      this.camService.deleteCam(roomId);
     } else {
       this.map.set(roomId, room);
     }

--- a/backend/src/cam/cam.controller.ts
+++ b/backend/src/cam/cam.controller.ts
@@ -1,17 +1,31 @@
-import { Controller, Post, Body, Get, Param } from '@nestjs/common';
+import {
+  Controller,
+  Post,
+  Body,
+  Get,
+  Param,
+  UseGuards,
+  Session,
+  Delete,
+} from '@nestjs/common';
 
 import ResponseEntity from '../common/response-entity';
-import { CreateCamDto } from './cam.dto';
+import { LoginGuard } from '../login/login.guard';
+import { ExpressSession } from '../types/session';
+import { RequestCamDto } from './cam.dto';
 import { Cam } from './cam.entity';
 import { CamService } from './cam.service';
 
-@Controller('api/cam')
+@Controller('/api/cam')
+@UseGuards(LoginGuard)
 export class CamController {
   constructor(private camService: CamService) {}
 
   @Post() async createCam(
-    @Body() cam: CreateCamDto,
+    @Body() cam: RequestCamDto,
+    @Session() session: ExpressSession,
   ): Promise<ResponseEntity<number>> {
+    cam.userId = session.user?.id;
     const savedCam = await this.camService.createCam(cam);
 
     return ResponseEntity.created(savedCam.id);
@@ -23,5 +37,15 @@ export class CamController {
     const cam = await this.camService.findOne(url);
 
     return ResponseEntity.ok<Cam>(cam);
+  }
+
+  @Delete() async deleteCam(
+    @Body() cam: RequestCamDto,
+    @Session() session: ExpressSession,
+  ): Promise<ResponseEntity<number>> {
+    cam.userId = session.user?.id;
+    await this.camService.deleteCam(cam);
+
+    return ResponseEntity.noContent();
   }
 }

--- a/backend/src/cam/cam.dto.ts
+++ b/backend/src/cam/cam.dto.ts
@@ -1,8 +1,9 @@
 import { Cam } from './cam.entity';
 
-export type CreateCamDto = {
+export type RequestCamDto = {
   name: string;
   serverId: number;
+  userId: number | null;
 };
 
 export class ResponseCamDto {

--- a/backend/src/cam/cam.entity.ts
+++ b/backend/src/cam/cam.entity.ts
@@ -7,6 +7,7 @@ import {
 } from 'typeorm';
 
 import { Server } from '../server/server.entity';
+import { User } from '../user/user.entity';
 
 @Entity()
 export class Cam {
@@ -19,9 +20,15 @@ export class Cam {
   @Column()
   url: string;
 
-  @ManyToOne(() => Server)
+  @ManyToOne(() => Server, { onDelete: 'CASCADE' })
   server: Server;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  user: User;
 
   @RelationId((cam: Cam) => cam.server)
   serverId: number;
+
+  @RelationId((cam: Cam) => cam.user)
+  ownerId: number;
 }

--- a/backend/src/cam/cam.module.ts
+++ b/backend/src/cam/cam.module.ts
@@ -9,10 +9,19 @@ import { Cam } from './cam.entity';
 import { ServerRepository } from '../server/server.repository';
 import { CamRepository } from './cam.repository';
 import { Server } from '../server/server.entity';
+import { UserRepository } from '../user/user.repository';
+import { User } from '../user/user.entity';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Cam, Server, CamRepository, ServerRepository]),
+    TypeOrmModule.forFeature([
+      Cam,
+      Server,
+      CamRepository,
+      ServerRepository,
+      User,
+      UserRepository,
+    ]),
   ],
   providers: [CamGateway, CamInnerService, CamService],
   controllers: [CamController],

--- a/frontend/src/components/Cam/Cam.tsx
+++ b/frontend/src/components/Cam/Cam.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
+import { useRecoilValue } from 'recoil';
 
 import ButtonBar from './Menu/ButtonBar';
 import ChattingTab from './Menu/ChattingTab';
@@ -15,6 +16,7 @@ import CamNotFoundPage from './Page/CamNotFoundPage';
 import CamLoadingPage from './Page/CamLoadingPage';
 import CamNotAvailablePage from './Page/CamNotAvailablePage';
 import CamErrorPage from './Page/CamErrorPage';
+import userState from '../../atoms/user';
 
 const Container = styled.div`
   width: 100vw;
@@ -39,7 +41,8 @@ const UpperTab = styled.div`
 `;
 
 function Cam(): JSX.Element {
-  const [userInfo, setUserInfo] = useState<UserInfo>({ roomId: null, nickname: null });
+  const user = useRecoilValue(userState);
+  const [userInfo, setUserInfo] = useState<UserInfo>({ roomId: null, nickname: user?.nickname || null });
   const [statusCode, setStatusCode] = useState(0);
 
   const camRef = useRef<HTMLDivElement>(null);

--- a/frontend/src/components/Cam/Menu/ButtonBar.tsx
+++ b/frontend/src/components/Cam/Menu/ButtonBar.tsx
@@ -37,6 +37,7 @@ const Container = styled.div<{ isMouseOnCamPage: boolean }>`
   transition: bottom 0.5s ease;
   position: absolute;
   bottom: ${(props) => (props.isMouseOnCamPage ? '0' : '-8vh')};
+  background-color: black;
 `;
 
 const ButtonContainer = styled.div`

--- a/frontend/src/components/Cam/Menu/UserListTab.tsx
+++ b/frontend/src/components/Cam/Menu/UserListTab.tsx
@@ -43,9 +43,9 @@ function UserListTab(): JSX.Element {
       isActive={isUserListTabActive}
     >
       <Container isActive={isUserListTabActive}>
-        <LocalUserScreen />
+        <LocalUserScreen numOfScreen={1} />
         {screenList.map((screen: Screen) => (
-          <UserScreen key={screen.userId} stream={screen.stream} userId={screen.userId} />
+          <UserScreen key={screen.userId} stream={screen.stream} userId={screen.userId} numOfScreen={1} />
         ))}
       </Container>
     </Draggable>

--- a/frontend/src/components/Cam/Screen/DefaultScreen.tsx
+++ b/frontend/src/components/Cam/Screen/DefaultScreen.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 
 const Container = styled.div`
-  width: 100%;
+  width: 90%;
   max-height: 100%;
   display: flex;
   justify-content: center;

--- a/frontend/src/components/Cam/Screen/LocalUserScreen.tsx
+++ b/frontend/src/components/Cam/Screen/LocalUserScreen.tsx
@@ -5,22 +5,29 @@ import DefaultScreen from './DefaultScreen';
 import { CamStoreContext } from '../CamStore';
 import StreamStatusIndicator from './StreamStatusIndicator';
 
-const Container = styled.div`
+const Container = styled.div<{ numOfScreen: number }>`
   position: relative;
-  width: 100%;
+  width: calc(100% / ${(props) => Math.ceil(props.numOfScreen ** 0.5)});
+  height: calc(100% / ${(props) => Math.floor((props.numOfScreen + 1) ** 0.5)});
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  height: 90%;
+  aspect-ratio: 16/9;
+  overflow: hidden;
 `;
 
 const Video = styled.video`
   max-height: 100%;
-  width: 100%;
+  width: 90%;
 `;
 
-function LocalUserScreen(): JSX.Element {
+type LocalUserScreenProps = {
+  numOfScreen: number;
+};
+
+function LocalUserScreen(props: LocalUserScreenProps): JSX.Element {
+  const { numOfScreen } = props;
   const videoRef = useRef<HTMLVideoElement>(null);
   const { localStream, localStatus, userInfo } = useContext(CamStoreContext);
 
@@ -34,7 +41,7 @@ function LocalUserScreen(): JSX.Element {
   });
 
   return (
-    <Container>
+    <Container numOfScreen={numOfScreen}>
       {localStatus.stream && localStatus.video ? (
         <Video ref={videoRef} playsInline autoPlay muted>
           <track kind="captions" />

--- a/frontend/src/components/Cam/Screen/MainScreen.tsx
+++ b/frontend/src/components/Cam/Screen/MainScreen.tsx
@@ -9,16 +9,13 @@ import LocalUserScreen from './LocalUserScreen';
 import UserScreen from './UserScreen';
 import { SharedScreenStoreContext } from '../SharedScreen/SharedScreenStore';
 
-const Container = styled.div<{ activeTab: string[]; numOfScreen: number }>`
+const Container = styled.div<{ activeTab: string[] }>`
   width: ${(props) => props.activeTab[0]};
   height: 90vh;
   background-color: black;
-  display: grid;
-  grid-template-columns: repeat(${(props) => Math.ceil(props.numOfScreen ** 0.5)}, minmax(30%, auto));
-  grid-auto-rows: minmax(100px, auto);
-  gap: 20px;
-  justify-items: space-evenly;
+  display: flex;
   align-items: center;
+  flex-wrap: wrap;
   transition: all 0.5s ease;
 `;
 
@@ -38,17 +35,22 @@ function MainScreen(): JSX.Element {
 
   if (sharedScreen !== null) {
     return (
-      <Container activeTab={countActiveTab()} onAnimationEnd={handleAnimationEnd} numOfScreen={1}>
+      <Container activeTab={countActiveTab()} onAnimationEnd={handleAnimationEnd}>
         <SharedScreen stream={sharedScreen} />
       </Container>
     );
   }
 
   return (
-    <Container activeTab={countActiveTab()} onAnimationEnd={handleAnimationEnd} numOfScreen={screenList.length + 1}>
-      <LocalUserScreen />
+    <Container activeTab={countActiveTab()} onAnimationEnd={handleAnimationEnd}>
+      <LocalUserScreen numOfScreen={screenList.length + 1} />
       {screenList.map((screen: Screen) => (
-        <UserScreen key={screen.userId} stream={screen.stream} userId={screen.userId} />
+        <UserScreen
+          key={screen.userId}
+          stream={screen.stream}
+          userId={screen.userId}
+          numOfScreen={screenList.length + 1}
+        />
       ))}
     </Container>
   );

--- a/frontend/src/components/Cam/Screen/UserScreen.tsx
+++ b/frontend/src/components/Cam/Screen/UserScreen.tsx
@@ -10,26 +10,29 @@ import { CamStoreContext } from '../CamStore';
 type UserScreenProps = {
   stream: MediaStream | undefined;
   userId: string;
+  numOfScreen: number;
 };
 
-const Container = styled.div`
+const Container = styled.div<{ numOfScreen: number }>`
   position: relative;
-  width: 100%;
+  width: calc(100% / ${(props) => Math.ceil(props.numOfScreen ** 0.5)});
+  height: calc(100% / ${(props) => Math.floor((props.numOfScreen + 1) ** 0.5)});
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  height: 90%;
+  aspect-ratio: 16/9;
+  overflow: hidden;
 `;
 
 const Video = styled.video<{ isSpeaking: boolean }>`
   max-height: 100%;
-  width: 100%;
+  width: 90%;
   border: ${(props) => (props.isSpeaking ? '2px solid green' : 'none')};
 `;
 
 function UserScreen(props: UserScreenProps): JSX.Element {
-  const { stream, userId } = props;
+  const { stream, userId, numOfScreen } = props;
   const { socket } = useContext(CamStoreContext);
   const videoRef = useRef<HTMLVideoElement>(null);
   const [nickname, setNickname] = useState<string>('김철수');
@@ -109,7 +112,7 @@ function UserScreen(props: UserScreenProps): JSX.Element {
   }, [control]);
 
   return (
-    <Container onContextMenu={handleContextMenu}>
+    <Container onContextMenu={handleContextMenu} numOfScreen={numOfScreen}>
       {status.stream && status.video && control.video ? (
         <Video ref={videoRef} playsInline autoPlay isSpeaking={status.speaking && status.audio}>
           <track kind="captions" />

--- a/frontend/src/components/Main/Cam/CamListItem.tsx
+++ b/frontend/src/components/Main/Cam/CamListItem.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
 import { BoostCamMainIcons } from '../../../utils/SvgIcons';
@@ -10,7 +11,7 @@ type CamListItemProps = {
   url: string;
 };
 
-const Container = styled.a`
+const Container = styled.div`
   width: 100%;
   height: 25px;
 
@@ -26,7 +27,6 @@ const Container = styled.a`
   overflow: hidden;
   text-overflow: ellipsis;
   color: inherit;
-  text-decoration: none;
 
   &:hover {
     cursor: pointer;
@@ -47,10 +47,14 @@ const CamNameSpan = styled.span`
 
 function CamListItem(props: CamListItemProps): JSX.Element {
   const { name, url } = props;
-  const camURL = `/cam?roomid=${url}`;
+  const navigate = useNavigate();
+
+  const onClickCam = () => {
+    navigate(`/cam?roomid=${url}`);
+  };
 
   return (
-    <Container href={camURL}>
+    <Container onClick={onClickCam}>
       <HashIcon />
       <CamNameSpan>{name}</CamNameSpan>
     </Container>

--- a/frontend/src/components/Main/Cam/CreateCamModal.tsx
+++ b/frontend/src/components/Main/Cam/CreateCamModal.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 
 import { MainStoreContext } from '../MainStore';
 import { BoostCamMainIcons } from '../../../utils/SvgIcons';
+import fetchData from '../../../utils/fetchMethods';
 
 const { Close } = BoostCamMainIcons;
 
@@ -147,6 +148,11 @@ type CreateModalForm = {
   description: string;
 };
 
+type PostCamData = {
+  name: string;
+  serverId: string;
+};
+
 function CreateCamModal(): JSX.Element {
   const {
     register,
@@ -159,16 +165,8 @@ function CreateCamModal(): JSX.Element {
 
   const onSubmitCreateCamModal = async (data: { name: string; description: string }) => {
     const { name } = data;
-    await fetch('api/cam', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        name: name.trim(),
-        serverId: selectedServer.server.id,
-      }),
-    });
+    const requestBody: PostCamData = { name, serverId: selectedServer.server.id };
+    await fetchData<PostCamData, null>('POST', '/api/cam', requestBody);
     setIsModalOpen(false);
     getServerCamList();
   };


### PR DESCRIPTION
- 기존 screen 배치 방식인 grid 대신 flex를 사용합니다.
- 이제 video toggle, audio hightlight가 발생해도 box size가 변하지 않아서 video가 움직이지 않습니다.

- cam으로 이동하는 방식이 a tag여서 내부 routing이 발생하지 않았습니다. spa를 유지하기 위해서 navigate로 변경했습니다.
- 로그인 된 사용자는 nickname을 가져와서 기본 닉네임으로 지정합니다. 이제 매번 번거롭게 닉네임을 입력할 필요가 없습니다.
- cam 삭제 방식을 변경 중입니다. 사람이 없는 cam도 삭제되지 않습니다. 추후 channel과 같은 방법으로 만든 사람이 삭제할 수 있도록 변경 예정입니다.