### PR TITLE
entity id를 number로 받기 위해 column type을 int로 수정

### DIFF
--- a/backend/src/cam/cam.controller.ts
+++ b/backend/src/cam/cam.controller.ts
@@ -8,6 +8,7 @@ import {
   Session,
   Delete,
   ForbiddenException,
+  ParseIntPipe,
 } from '@nestjs/common';
 
 import ResponseEntity from '../common/response-entity';
@@ -41,7 +42,7 @@ export class CamController {
   }
 
   @Delete('/:id') async deleteCam(
-    @Param('id') id: number,
+    @Param('id', new ParseIntPipe()) id: number,
     @Session() session: ExpressSession,
   ): Promise<ResponseEntity<number>> {
     const cam = await this.camService.findOneById(id);

--- a/backend/src/cam/cam.entity.ts
+++ b/backend/src/cam/cam.entity.ts
@@ -11,7 +11,7 @@ import { User } from '../user/user.entity';
 
 @Entity()
 export class Cam {
-  @PrimaryGeneratedColumn({ type: 'bigint' })
+  @PrimaryGeneratedColumn()
   id: number;
 
   @Column()

--- a/backend/src/channel/channel.controller.ts
+++ b/backend/src/channel/channel.controller.ts
@@ -8,6 +8,7 @@ import {
   Patch,
   Session,
   UseGuards,
+  ParseIntPipe,
 } from '@nestjs/common';
 import { LoginGuard } from '../login/login.guard';
 import { ExpressSession } from '../types/session';
@@ -29,14 +30,14 @@ export class ChannelController {
     this.userChannelService = userChannelService;
   }
   @Get(':channelId') async findOne(
-    @Param('channelId') id: number,
+    @Param('channelId', new ParseIntPipe()) id: number,
   ): Promise<ResponseEntity<Channel>> {
     const foundChannel = await this.channelService.findOne(id);
     return ResponseEntity.ok<Channel>(foundChannel);
   }
 
   @Get(':channelId/auth') async checkAuthority(
-    @Param('channelId') id: number,
+    @Param('channelId', new ParseIntPipe()) id: number,
     @Session() session: ExpressSession,
   ): Promise<ResponseEntity<boolean>> {
     const foundChannel = await this.channelService.findOne(id);
@@ -55,7 +56,7 @@ export class ChannelController {
     return ResponseEntity.ok<Channel>(savedChannel);
   }
   @Patch(':channelId') async updateChannel(
-    @Param('channelId') id: number,
+    @Param('channelId', new ParseIntPipe()) id: number,
     @Body() channel: ChannelFormDto,
     @Session() session: ExpressSession,
   ): Promise<ResponseEntity<Channel>> {
@@ -68,7 +69,7 @@ export class ChannelController {
   }
 
   @Delete(':channelId') async deleteChannel(
-    @Param('channelId') id: number,
+    @Param('channelId', new ParseIntPipe()) id: number,
   ): Promise<ResponseEntity<null>> {
     await this.channelService.deleteChannel(id);
     return ResponseEntity.noContent();

--- a/backend/src/channel/channel.entity.ts
+++ b/backend/src/channel/channel.entity.ts
@@ -10,7 +10,7 @@ import { User } from '../user/user.entity';
 
 @Entity()
 export class Channel {
-  @PrimaryGeneratedColumn({ type: 'bigint' })
+  @PrimaryGeneratedColumn()
   id: number;
 
   @Column()

--- a/backend/src/comment/comment.entity.ts
+++ b/backend/src/comment/comment.entity.ts
@@ -11,7 +11,7 @@ import { User } from '../user/user.entity';
 
 @Entity()
 export class Comment {
-  @PrimaryGeneratedColumn({ type: 'bigint' })
+  @PrimaryGeneratedColumn()
   id: number;
 
   @Column()

--- a/backend/src/emoticon/emoticon.entity.ts
+++ b/backend/src/emoticon/emoticon.entity.ts
@@ -2,7 +2,7 @@ import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
 
 @Entity()
 export class Emoticon {
-  @PrimaryGeneratedColumn({ type: 'bigint' })
+  @PrimaryGeneratedColumn()
   id: number;
 
   @Column()

--- a/backend/src/message/message.controller.ts
+++ b/backend/src/message/message.controller.ts
@@ -1,4 +1,11 @@
-import { Controller, Get, Query, Session, UseGuards } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  ParseIntPipe,
+  Query,
+  Session,
+  UseGuards,
+} from '@nestjs/common';
 import { ApiExtraModels, ApiOkResponse } from '@nestjs/swagger';
 import ResponseEntity from '../common/response-entity';
 import { LoginGuard } from '../login/login.guard';
@@ -18,7 +25,7 @@ export class MessageController {
   @Get()
   async findMessagesByChannelId(
     @Session() session: ExpressSession,
-    @Query('channelId') channelId: number,
+    @Query('channelId', new ParseIntPipe()) channelId: number,
   ): Promise<ResponseEntity<MessageDto[]>> {
     const sender = session.user;
     const channelMessages = await this.messageService.findMessagesByChannelId(

--- a/backend/src/message/message.entity.ts
+++ b/backend/src/message/message.entity.ts
@@ -11,7 +11,7 @@ import {
 
 @Entity()
 export class Message {
-  @PrimaryGeneratedColumn({ type: 'bigint' })
+  @PrimaryGeneratedColumn()
   id: number;
 
   @Column()

--- a/backend/src/server/server.controller.ts
+++ b/backend/src/server/server.controller.ts
@@ -12,6 +12,7 @@ import {
   UploadedFile,
   HttpCode,
   HttpStatus,
+  ParseIntPipe,
 } from '@nestjs/common';
 
 import { ServerService } from './server.service';
@@ -47,14 +48,14 @@ export class ServerController {
   @ApiOkResponse(serverWithUserDtoSchema)
   @Get('/:id/users')
   async findOneWithUsers(
-    @Param('id') id: number,
+    @Param('id', new ParseIntPipe()) id: number,
   ): Promise<ResponseEntity<ServerWithUsersDto>> {
     const serverWithUsers = await this.serverService.findOneWithUsers(id);
     return ResponseEntity.ok(serverWithUsers);
   }
 
   @Get('/:id/cam') async findCams(
-    @Param('id') id: number,
+    @Param('id', new ParseIntPipe()) id: number,
   ): Promise<ResponseEntity<ResponseCamDto[]>> {
     const cam = await this.camService.getCamList(id);
     return ResponseEntity.ok(cam);
@@ -62,7 +63,9 @@ export class ServerController {
 
   @ApiOkResponse(serverCodeSchema)
   @Get('/:id/code')
-  async findCode(@Param('id') id: number): Promise<ResponseEntity<string>> {
+  async findCode(
+    @Param('id', new ParseIntPipe()) id: number,
+  ): Promise<ResponseEntity<string>> {
     const code = await this.serverService.findCode(id);
     return ResponseEntity.ok(code);
   }
@@ -72,7 +75,7 @@ export class ServerController {
   async refreshCode(
     @Session()
     session: ExpressSession,
-    @Param('id') id: number,
+    @Param('id', new ParseIntPipe()) id: number,
   ): Promise<ResponseEntity<string>> {
     const user = session.user;
     const code = await this.serverService.refreshCode(id, user);
@@ -114,7 +117,7 @@ export class ServerController {
   async updateServer(
     @Session()
     session: ExpressSession,
-    @Param('id') id: number,
+    @Param('id', new ParseIntPipe()) id: number,
     @Body() requestServerDto: RequestServerDto,
     @UploadedFile() icon: Express.Multer.File,
   ): Promise<ResponseEntity<string>> {
@@ -140,7 +143,7 @@ export class ServerController {
   async deleteServer(
     @Session()
     session: ExpressSession,
-    @Param('id') id: number,
+    @Param('id', new ParseIntPipe()) id: number,
   ): Promise<ResponseEntity<string>> {
     const user = session.user;
     await this.serverService.deleteServer(id, user);

--- a/backend/src/server/server.entity.ts
+++ b/backend/src/server/server.entity.ts
@@ -12,7 +12,7 @@ import { User } from '../user/user.entity';
 
 @Entity()
 export class Server {
-  @PrimaryGeneratedColumn({ type: 'bigint' })
+  @PrimaryGeneratedColumn()
   id: number;
 
   @Column()

--- a/backend/src/user-channel/user-channel.controller.ts
+++ b/backend/src/user-channel/user-channel.controller.ts
@@ -10,6 +10,7 @@ import {
   HttpStatus,
   HttpException,
   Query,
+  ParseIntPipe,
 } from '@nestjs/common';
 import ResponseEntity from '../common/response-entity';
 import { LoginGuard } from '../login/login.guard';
@@ -30,7 +31,7 @@ export class UserChannelController {
 
   @Get('/channels/joined/')
   async getJoinedChannelList(
-    @Param('serverId') serverId: number,
+    @Param('serverId', new ParseIntPipe()) serverId: number,
     @Session() session: ExpressSession,
   ) {
     const joinedChannelList =
@@ -43,7 +44,7 @@ export class UserChannelController {
 
   @Get('/channels/notjoined/')
   async getNotJoinedChannelList(
-    @Param('serverId') serverId: number,
+    @Param('serverId', new ParseIntPipe()) serverId: number,
     @Session() session: ExpressSession,
   ) {
     const response =
@@ -56,8 +57,8 @@ export class UserChannelController {
 
   @Get('/channels/users')
   async getJoinedUserList(
-    @Param('serverId') serverId: number,
-    @Query('channelId') channelId: number,
+    @Param('serverId', new ParseIntPipe()) serverId: number,
+    @Query('channelId', new ParseIntPipe()) channelId: number,
   ) {
     const response =
       await this.userChannelService.findJoinedUserListByChannelId(
@@ -70,7 +71,7 @@ export class UserChannelController {
   @Post('/channels')
   async joinNewChannel(
     @Body('channelId') channelId: number,
-    @Param('serverId') serverId: number,
+    @Param('serverId', new ParseIntPipe()) serverId: number,
     @Session() session: ExpressSession,
   ) {
     const selectedChannel = await this.channelService.findOne(channelId);
@@ -83,7 +84,7 @@ export class UserChannelController {
 
   @Delete('/channels/:channelId')
   async delete(
-    @Param('channelId') channeld: number,
+    @Param('channelId', new ParseIntPipe()) channeld: number,
     @Session() session: ExpressSession,
   ) {
     try {

--- a/backend/src/user-channel/user-channel.entity.ts
+++ b/backend/src/user-channel/user-channel.entity.ts
@@ -5,7 +5,7 @@ import { Channel } from '../channel/channel.entity';
 
 @Entity()
 export class UserChannel {
-  @PrimaryGeneratedColumn({ type: 'bigint' })
+  @PrimaryGeneratedColumn()
   id: number;
 
   @ManyToOne(() => User, { onDelete: 'CASCADE' })

--- a/backend/src/user-server/user-server.controller.ts
+++ b/backend/src/user-server/user-server.controller.ts
@@ -9,6 +9,7 @@ import {
   HttpCode,
   HttpStatus,
   Get,
+  ParseIntPipe,
 } from '@nestjs/common';
 import { LoginGuard } from '../login/login.guard';
 import { ExpressSession } from '../types/session';
@@ -27,6 +28,7 @@ export class UserServerController {
     session: ExpressSession,
   ): Promise<ResponseEntity<UserServerListDto[]>> {
     const userId = session.user.id;
+    console.log(userId);
     const data = await this.userServerService.getServerListByUserId(userId);
 
     return ResponseEntity.ok(data);
@@ -48,7 +50,7 @@ export class UserServerController {
   async delete(
     @Session()
     session: ExpressSession,
-    @Param('id') id: number,
+    @Param('id', new ParseIntPipe()) id: number,
   ) {
     const userId = session.user.id;
     await this.userServerService.deleteById(id, userId);

--- a/backend/src/user-server/user-server.controller.ts
+++ b/backend/src/user-server/user-server.controller.ts
@@ -28,7 +28,6 @@ export class UserServerController {
     session: ExpressSession,
   ): Promise<ResponseEntity<UserServerListDto[]>> {
     const userId = session.user.id;
-    console.log(userId);
     const data = await this.userServerService.getServerListByUserId(userId);
 
     return ResponseEntity.ok(data);

--- a/backend/src/user-server/user-server.entity.ts
+++ b/backend/src/user-server/user-server.entity.ts
@@ -4,7 +4,7 @@ import { Server } from '../server/server.entity';
 
 @Entity()
 export class UserServer {
-  @PrimaryGeneratedColumn({ type: 'bigint' })
+  @PrimaryGeneratedColumn()
   id: number;
 
   @ManyToOne(() => User, { onDelete: 'CASCADE' })

--- a/backend/src/user/user.entity.ts
+++ b/backend/src/user/user.entity.ts
@@ -2,10 +2,10 @@ import { Entity, Column, PrimaryGeneratedColumn } from 'typeorm';
 
 @Entity()
 export class User {
-  @PrimaryGeneratedColumn({ type: 'bigint' })
+  @PrimaryGeneratedColumn()
   id: number;
 
-  @Column({ type: 'bigint' })
+  @Column()
   githubId: number;
 
   @Column()

--- a/frontend/src/components/Main/Cam/Modal/CreateCamModal.tsx
+++ b/frontend/src/components/Main/Cam/Modal/CreateCamModal.tsx
@@ -77,7 +77,7 @@ type CreateModalForm = {
 
 type PostCamData = {
   name: string;
-  serverId: string;
+  serverId: number;
 };
 
 function CreateCamModal(): JSX.Element {

--- a/frontend/src/components/Main/Channel/List/ChannelListItem.tsx
+++ b/frontend/src/components/Main/Channel/List/ChannelListItem.tsx
@@ -59,9 +59,8 @@ function ChannelListItem(props: ChannelListItemProps): JSX.Element {
     setDropdownInfo,
   } = useContext(MainStoreContext);
 
-  const onClickChannelBlock = ({ currentTarget }: React.MouseEvent<HTMLDivElement>) => {
-    const channelId = currentTarget.dataset.id;
-    if (channelId) setSelectedChannel(channelId);
+  const onClickChannelBlock = () => {
+    setSelectedChannel(dataId);
   };
 
   const onRightClickChannelItem = (e: React.MouseEvent<HTMLDivElement>) => {

--- a/frontend/src/components/Main/ContentsSection/ContentsSection.tsx
+++ b/frontend/src/components/Main/ContentsSection/ContentsSection.tsx
@@ -28,7 +28,7 @@ type ContentsSectionProps = {
   commentList: CommentListInfo;
 };
 
-const getJoinedUserList = async (selectedServer: MyServerData, selectedChannel: string) => {
+const getJoinedUserList = async (selectedServer: MyServerData, selectedChannel: number) => {
   const response = await fetchData<null, User[]>(
     'GET',
     `/api/user/servers/${selectedServer?.server.id}/channels/users?channelId=${selectedChannel}`,
@@ -36,7 +36,7 @@ const getJoinedUserList = async (selectedServer: MyServerData, selectedChannel: 
   return response;
 };
 
-const getSelectedChannelInfo = async (selectedChannel: string) => {
+const getSelectedChannelInfo = async (selectedChannel: number) => {
   const response = await fetchData<null, ChannelEntity>('GET', `/api/channels/${selectedChannel}`);
   return response;
 };

--- a/frontend/src/components/Main/ContentsSection/NoChannelSection.tsx
+++ b/frontend/src/components/Main/ContentsSection/NoChannelSection.tsx
@@ -167,7 +167,11 @@ function NoChannelSection(): JSX.Element {
     const resquestBody = {
       channelId: id,
     };
-    await fetchData<JoinChannelRequest, null>('POST', `/api/user/servers/${selectedServer}/channels`, resquestBody);
+    await fetchData<JoinChannelRequest, null>(
+      'POST',
+      `/api/user/servers/${selectedServer.server.id}/channels`,
+      resquestBody,
+    );
     getServerChannelList();
     socket.emit('joinChannel', { channelId: id });
     setIsModalOpen(false);

--- a/frontend/src/components/Main/MainSection.tsx
+++ b/frontend/src/components/Main/MainSection.tsx
@@ -46,7 +46,6 @@ function MainSection(): JSX.Element {
     const { data } = await fetchData<null, MessageData[]>('GET', `/api/messages?channelId=${selectedChannel}`);
 
     if (data) {
-      data.sort((a, b) => parseInt(a.id, 10) - parseInt(b.id, 10));
       setMessageList({
         messageData: data,
         isLoading: false,
@@ -58,7 +57,6 @@ function MainSection(): JSX.Element {
     if (!selectedMessageData) return;
     const { data } = await fetchData<null, CommentData[]>('GET', `/api/comments?messageId=${selectedMessageData.id}`);
     if (data) {
-      data.sort((a, b) => parseInt(a.id, 10) - parseInt(b.id, 10));
       setCommentList({
         commentData: data,
         isLoading: false,

--- a/frontend/src/types/comment.ts
+++ b/frontend/src/types/comment.ts
@@ -7,9 +7,9 @@ type CommentRequestBody = {
 };
 
 type CommentData = {
-  id: string;
+  id: number;
   messageId: string;
-  channelId: string;
+  channelId: number;
   contents: string;
   createdAt: string;
   sender: MessageSender;

--- a/frontend/src/types/main.ts
+++ b/frontend/src/types/main.ts
@@ -1,20 +1,20 @@
 type UserData = {
-  githubId: string;
-  id: string;
+  githubId: number;
+  id: number;
   nickname: string;
   profile: string;
 };
 
 type ServerData = {
   description: string;
-  id: string;
+  id: number;
   name: string;
   imgUrl: string;
   owner: UserData;
 };
 
 type MyServerData = {
-  id: string;
+  id: number;
   server: ServerData;
 };
 

--- a/frontend/src/types/message.ts
+++ b/frontend/src/types/message.ts
@@ -1,17 +1,17 @@
 type MessageRequestBody = {
-  channelId: string;
+  channelId: number;
   contents: string;
 };
 
 type MessageSender = {
-  id: string;
+  id: number;
   nickname: string;
   profile: string;
 };
 
 type MessageData = {
-  id: string;
-  channelId: string;
+  id: number;
+  channelId: number;
   contents: string;
   createdAt: string;
   sender: MessageSender;


### PR DESCRIPTION
typeORM에서 칼럼을 BigInt로 정의하면 값이 string이 들어옵니다. 그래서 이를 int로 변경하기로 합의하여 수정합니다.
- 컨트롤러에 string으로 받던 부분들을 number로 변경하기 위해서 ParseIntPipe를 연결하였습니다.
- 프론트엔드에서 id를 string으로 이용하던 부분들을 number로 수정하였습니다.
- 그외 몇몇 버그 수정