### PR TITLE
server list icon 버그 수정 및 backend 함수 일부 리팩토링

### DIFF
--- a/backend/src/channel/channel.entity.ts
+++ b/backend/src/channel/channel.entity.ts
@@ -5,8 +5,10 @@ import {
   PrimaryGeneratedColumn,
   ManyToOne,
   RelationId,
+  OneToMany,
 } from 'typeorm';
 import { User } from '../user/user.entity';
+import { UserChannel } from '../user-channel/user-channel.entity';
 
 @Entity()
 export class Channel {
@@ -24,6 +26,9 @@ export class Channel {
 
   @ManyToOne(() => User)
   owner: User;
+
+  @OneToMany(() => UserChannel, (userChannels) => userChannels.channel)
+  userChannels: UserChannel[];
 
   @RelationId((channel: Channel) => channel.owner)
   ownerId: number;

--- a/backend/src/channel/channel.repository.ts
+++ b/backend/src/channel/channel.repository.ts
@@ -1,4 +1,4 @@
-import { EntityRepository, Repository } from 'typeorm';
+import { Brackets, EntityRepository, Repository } from 'typeorm';
 import { Channel } from './channel.entity';
 
 @EntityRepository(Channel)
@@ -10,6 +10,28 @@ export class ChannelRepository extends Repository<Channel> {
   getChannelListByServerId(serverId: number) {
     return this.createQueryBuilder('channel')
       .where('channel.serverId = :serverId', { serverId })
+      .getMany();
+  }
+
+  getJoinedChannelList(userId: number, serverId: number) {
+    return this.createQueryBuilder('channel')
+      .leftJoin('channel.userChannels', 'user_channel')
+      .where('channel.serverId = :serverId', { serverId })
+      .andWhere('user_channel.userId = :userId', { userId })
+      .getMany();
+  }
+
+  getNotJoinedChannelList(userId: number, serverId: number) {
+    return this.createQueryBuilder('channel')
+      .leftJoin('channel.userChannels', 'user_channel')
+      .where('channel.serverId = :serverId', { serverId })
+      .andWhere(
+        new Brackets((qb) => {
+          qb.where('user_channel.userId != :userId', { userId }).orWhere(
+            'user_channel.userId IS NULL',
+          );
+        }),
+      )
       .getMany();
   }
 }

--- a/backend/src/server/server.controller.ts
+++ b/backend/src/server/server.controller.ts
@@ -98,13 +98,13 @@ export class ServerController {
       imgUrl = uploadedFile.Location;
     }
     const user = session.user;
-    const newServer = await this.serverService.create(
+    const newServerId = await this.serverService.create(
       user,
       requestServerDto,
       imgUrl,
     );
 
-    return ResponseEntity.created(newServer.id);
+    return ResponseEntity.created(newServerId);
   }
 
   @ApiOkResponse(serverCodeSchema)

--- a/backend/src/server/server.service.spec.ts
+++ b/backend/src/server/server.service.spec.ts
@@ -48,6 +48,7 @@ describe('ServerService', () => {
   const existsServerId = 1;
   const userId = 1;
   const newServerId = 2;
+  const newUserServerId = 1;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -168,7 +169,7 @@ describe('ServerService', () => {
       serverRepository.save.mockResolvedValue(newServer);
       serverRepository.findOne.mockResolvedValue(newServer);
       userServerRepository.findByUserIdAndServerId.mockResolvedValue(undefined);
-      userServerRepository.save.mockResolvedValue(newUserServer);
+      userServerRepository.save.mockResolvedValue(newUserServerId);
 
       const createdServerId = await serverService.create(
         user,
@@ -294,5 +295,8 @@ describe('ServerService', () => {
     existsServer.owner = user;
     existsServer.userServer = [existsUserServer];
     existsServer.code = v4();
+
+    newUserServer = new UserServer();
+    newUserServer.id = newUserServerId;
   };
 });

--- a/backend/src/server/server.service.spec.ts
+++ b/backend/src/server/server.service.spec.ts
@@ -47,6 +47,7 @@ describe('ServerService', () => {
 
   const existsServerId = 1;
   const userId = 1;
+  const newServerId = 2;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -169,15 +170,13 @@ describe('ServerService', () => {
       userServerRepository.findByUserIdAndServerId.mockResolvedValue(undefined);
       userServerRepository.save.mockResolvedValue(newUserServer);
 
-      const createdServer = await serverService.create(
+      const createdServerId = await serverService.create(
         user,
         requestServerDto,
         '',
       );
 
-      expect(createdServer.name).toBe(requestServerDto.name);
-      expect(createdServer.description).toBe(requestServerDto.description);
-      expect(createdServer.owner.id).toBe(user.id);
+      expect(createdServerId).toBe(newServerId);
     });
   });
 
@@ -281,6 +280,7 @@ describe('ServerService', () => {
     user.id = userId;
     requestServerDto = new RequestServerDto(serverName, serverDescription);
     newServer = new Server();
+    newServer.id = newServerId;
     newServer.description = serverDescription;
     newServer.name = serverName;
     newServer.owner = user;

--- a/backend/src/server/server.service.ts
+++ b/backend/src/server/server.service.ts
@@ -24,9 +24,6 @@ export class ServerService {
     @InjectRepository(ServerRepository)
     private serverRepository: ServerRepository,
   ) {}
-  findAll(): Promise<Server[]> {
-    return this.serverRepository.find({ relations: ['owner'] });
-  }
 
   findOne(id: number): Promise<Server> {
     return this.serverRepository.findOne({ id: id });
@@ -71,7 +68,7 @@ export class ServerService {
     user: User,
     requestServerDto: RequestServerDto,
     imgUrl: string | undefined,
-  ): Promise<Server> {
+  ): Promise<number> {
     const server = requestServerDto.toServerEntity();
     server.owner = user;
     server.imgUrl = imgUrl || '';
@@ -80,7 +77,7 @@ export class ServerService {
     const createdServer = await this.serverRepository.save(server);
     this.userServerService.create(user, createdServer.code);
 
-    return createdServer;
+    return createdServer.id;
   }
 
   async updateServer(

--- a/backend/src/user-channel/user-channel.repository.ts
+++ b/backend/src/user-channel/user-channel.repository.ts
@@ -16,14 +16,6 @@ export class UserChannelRepository extends Repository<UserChannel> {
       .getMany();
   }
 
-  getJoinedChannelListByUserId(userId: number, serverId: number) {
-    return this.createQueryBuilder('user_channel')
-      .leftJoinAndSelect('user_channel.channel', 'channel')
-      .where('user_channel.user = :userId', { userId: userId })
-      .andWhere('user_channel.server = :serverId', { serverId: serverId })
-      .getMany();
-  }
-
   getJoinedUserListByChannelId(serverId: number, channelId: number) {
     return this.createQueryBuilder('user_channel')
       .innerJoinAndSelect('user_channel.user', 'user')

--- a/backend/src/user-channel/user-channel.service.ts
+++ b/backend/src/user-channel/user-channel.service.ts
@@ -39,37 +39,22 @@ export class UserChannelService {
     serverId: number,
     userId: number,
   ): Promise<ChannelResponseDto[]> {
-    const result =
-      await this.userChannelRepository.getJoinedChannelListByUserId(
-        userId,
-        serverId,
-      );
-    const channelList = result.map((userChannel) =>
-      ChannelResponseDto.fromEntity(userChannel.channel),
+    const joinedChannelList = await this.channelRepository.getJoinedChannelList(
+      userId,
+      serverId,
     );
-    return channelList;
+
+    return joinedChannelList.map(ChannelResponseDto.fromEntity);
   }
 
   async getNotJoinedChannelListByUserId(
     serverId: number,
     userId: number,
   ): Promise<ChannelResponseDto[]> {
-    const allChannelList =
-      await this.channelRepository.getChannelListByServerId(serverId);
-    const joinedList =
-      await this.userChannelRepository.getJoinedChannelListByUserId(
-        userId,
-        serverId,
-      );
-    const joinedChannelList = joinedList.map(
-      (userChannel) => userChannel.channel.id,
-    );
+    const notJoinedChannelList =
+      await this.channelRepository.getNotJoinedChannelList(userId, serverId);
 
-    const notJoinedList = allChannelList
-      .filter((channel) => !joinedChannelList.includes(channel.id))
-      .map(ChannelResponseDto.fromEntity);
-
-    return notJoinedList;
+    return notJoinedChannelList.map(ChannelResponseDto.fromEntity);
   }
 
   async deleteByUserIdAndChannelId(userId: number, channelId: number) {

--- a/backend/src/user-server/user-server.controller.ts
+++ b/backend/src/user-server/user-server.controller.ts
@@ -39,8 +39,8 @@ export class UserServerController {
     @Body() { code },
   ) {
     const user = session.user;
-    const newUserServer = await this.userServerService.create(user, code);
-    return ResponseEntity.created(newUserServer.id);
+    const newUserServerId = await this.userServerService.create(user, code);
+    return ResponseEntity.created(newUserServerId);
   }
 
   @Delete('/:id')

--- a/backend/src/user-server/user-server.service.spec.ts
+++ b/backend/src/user-server/user-server.service.spec.ts
@@ -42,6 +42,7 @@ describe('UserServerService', () => {
   const userId = 1;
   const serverId = 1;
   const existUserServerId = 1;
+  const userServerId = 2;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -75,10 +76,9 @@ describe('UserServerService', () => {
       serverRepository.findOne.mockResolvedValue(server);
       userServerRepository.findByUserIdAndServerId.mockResolvedValue(undefined);
 
-      const newUserServer = await service.create(user, server.code);
+      const newUserServerId = await service.create(user, server.code);
 
-      expect(newUserServer.user).toBe(user);
-      expect(newUserServer.server).toBe(server);
+      expect(newUserServerId).toBe(userServerId);
     });
 
     it('서버가 존재하지 않는 경우', async () => {
@@ -186,6 +186,7 @@ describe('UserServerService', () => {
     server.code = v4();
 
     userServer = new UserServer();
+    userServer.id = userServerId;
     userServer.user = user;
     userServer.server = server;
 

--- a/backend/src/user-server/user-server.service.ts
+++ b/backend/src/user-server/user-server.service.ts
@@ -22,7 +22,7 @@ export class UserServerService {
     private userServerRepository: UserServerRepository,
   ) {}
 
-  async create(user: User, code: string): Promise<UserServer> {
+  async create(user: User, code: string): Promise<number> {
     const newUserServer = new UserServer();
     newUserServer.user = user;
     newUserServer.server = await this.serverService.findByCode(code);
@@ -38,7 +38,8 @@ export class UserServerService {
       throw new BadRequestException('이미 등록된 서버입니다.');
     }
 
-    return this.userServerRepository.save(newUserServer);
+    const newUserServerId = await this.userServerRepository.save(newUserServer);
+    return newUserServerId.id;
   }
 
   async deleteById(id: number, userId: number): Promise<DeleteResult> {

--- a/frontend/src/components/Main/Server/List/ServerListTab.tsx
+++ b/frontend/src/components/Main/Server/List/ServerListTab.tsx
@@ -31,8 +31,7 @@ const ServerIconBox = styled.div<{ selected: boolean }>`
 
   margin-top: 10px;
   box-sizing: border-box;
-  ${(props) => (props.selected ? 'border: 5px solid gray;' : '')}
-
+  ${(props) => (props.selected ? ' background-color:gray;' : '')}
   border-radius: 20px;
 
   display: flex;
@@ -50,7 +49,7 @@ const ServerImg = styled.div<{ imgUrl: string }>`
   background-size: cover;
   background-repeat: no-repeat;
   border-radius: 20px;
-  position: fixed;
+  background-color: white;
 `;
 
 const ServerName = styled.div`
@@ -61,7 +60,6 @@ const ServerName = styled.div`
   background-color: white;
   border-radius: 20px;
   text-align: center;
-  position: fixed;
 `;
 
 const AddServerButton = styled.div`

--- a/frontend/src/components/Main/Server/Modal/ServerDeleteCheckModal.tsx
+++ b/frontend/src/components/Main/Server/Modal/ServerDeleteCheckModal.tsx
@@ -9,7 +9,7 @@ const Container = styled.div`
   height: 100vh;
   left: 0px;
   right: 0px;
-
+  top: 0px;
   display: flex;
   justify-content: space-around;
   align-items: center;

--- a/frontend/src/components/Main/Server/Modal/ServerInfoModal.tsx
+++ b/frontend/src/components/Main/Server/Modal/ServerInfoModal.tsx
@@ -87,7 +87,7 @@ const InfoDiv = styled.div`
   color: black;
   width: 95%;
   min-height: 80px;
-  max-height: 150px;
+  max-height: 110px;
   overflow-y: auto;
   margin: 0px;
 

--- a/frontend/src/components/Main/Server/Modal/ServerInfoModal.tsx
+++ b/frontend/src/components/Main/Server/Modal/ServerInfoModal.tsx
@@ -44,6 +44,7 @@ const ServerIcon = styled.img`
   height: 40px;
   margin-right: 10px;
   border-radius: 5px;
+  background-color: white;
 `;
 
 const ServerName = styled.div`

--- a/frontend/src/components/Main/Server/Modal/ServerSettingModal.tsx
+++ b/frontend/src/components/Main/Server/Modal/ServerSettingModal.tsx
@@ -101,7 +101,21 @@ const InputLabel = styled.label`
 const ImagePreview = styled.img`
   width: 40px;
   height: 40px;
+  background-color: white;
+  border-radius: 5px;
 `;
+
+const ServerName = styled.div`
+  width: 40px;
+  height: 40px;
+  min-width: 40px;
+  font-size: 30px;
+  font-weight: bold;
+  background-color: #ffffff;
+  border-radius: 5px;
+  text-align: center;
+`;
+
 const MessageFailToPost = styled.span`
   color: red;
   font-size: 16px;
@@ -276,7 +290,7 @@ function ServerSettingModal(): JSX.Element {
         <InputName>서버 아이콘 변경</InputName>
         <InputDiv>
           <ImageInputDiv>
-            <ImagePreview src={imagePreview} />
+            {imagePreview ? <ImagePreview src={imagePreview} /> : <ServerName>{serverName[0]}</ServerName>}
             <InputLabel htmlFor="file">파일을 선택하세요</InputLabel>
             <InputFile id="file" type="file" onChange={onChangePreviewImage} />
           </ImageInputDiv>

--- a/frontend/src/components/core/Dropdown.tsx
+++ b/frontend/src/components/core/Dropdown.tsx
@@ -17,7 +17,7 @@ const DropdownBackground = styled.div`
   width: 200vw;
   height: 200vh;
   margin-left: -50vw;
-  margin-top: -50vh;
+  margin-top: -100vh;
   background-color: rgb(0, 0, 0, 0.1);
   z-index: 3;
 `;


### PR DESCRIPTION
- server icon fixed속성을 제거하여 모달창 background 뒤에 나타나도록 변경하였습니다.
- create() 함수의 리턴타입을 생성된 entity의 id인 number로 변경하였습니다.
- joined, notJoined Channel 목록을 가져오는 로직을 쿼리문에서 처리하도록 변경하였습니다.