### PR TITLE
ContentsSection 관련 수정

### DIFF
--- a/frontend/src/components/Main/Cam/List/CamList.tsx
+++ b/frontend/src/components/Main/Cam/List/CamList.tsx
@@ -23,7 +23,7 @@ const CamListBody = styled.div`
 `;
 
 function CamList(): JSX.Element {
-  const [isListOpen, setIsListOpen] = useState<boolean>(false);
+  const [isListOpen, setIsListOpen] = useState<boolean>(true);
   const { serverCamList } = useContext(MainStoreContext);
 
   const listElements = serverCamList.map((cam: { id: number; name: string; url: string }) => (

--- a/frontend/src/components/Main/Channel/List/ChannelList.tsx
+++ b/frontend/src/components/Main/Channel/List/ChannelList.tsx
@@ -24,7 +24,7 @@ const ChannelListBody = styled.div`
   font-size: 15px;
 `;
 function ChannelList(): JSX.Element {
-  const [isListOpen, setIsListOpen] = useState<boolean>(false);
+  const [isListOpen, setIsListOpen] = useState<boolean>(true);
   const { selectedServer, selectedChannel, serverChannelList } = useContext(MainStoreContext);
   const navigate = useNavigate();
   useEffect(() => {

--- a/frontend/src/components/Main/ContentsSection/ContentsSection.tsx
+++ b/frontend/src/components/Main/ContentsSection/ContentsSection.tsx
@@ -55,6 +55,7 @@ function ContentsSection(props: ContentsSectionProps): JSX.Element {
     const selectedChannelInfo = await getSelectedChannelInfo(selectedChannel);
     if (selectedChannelInfo.statusCode > 300) {
       setIsLoading(false);
+      setChannelInfo(undefined);
       return;
     }
     const joinedUserList = await getJoinedUserList(selectedServer, selectedChannel);

--- a/frontend/src/components/Main/ContentsSection/MessageSection.tsx
+++ b/frontend/src/components/Main/ContentsSection/MessageSection.tsx
@@ -33,15 +33,19 @@ const MessageSectionHeader = styled.div`
   border-bottom: 1px solid gray;
 `;
 
-const ChannelName = styled.div`
+const ChannelName = styled.span`
   margin-left: 15px;
   padding: 8px 12px;
   border-radius: 10px;
   background-color: #f0e7e7;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 `;
 
-const ChannelUserButton = styled.div`
+const ChannelUserButton = styled.span`
   margin-right: 15px;
+  min-width: 55px;
   padding: 3px 5px;
   border: 1px solid gray;
   border-radius: 10px;

--- a/frontend/src/components/Main/ContentsSection/MessageSection.tsx
+++ b/frontend/src/components/Main/ContentsSection/MessageSection.tsx
@@ -37,12 +37,7 @@ const ChannelName = styled.div`
   margin-left: 15px;
   padding: 8px 12px;
   border-radius: 10px;
-
-  cursor: pointer;
-
-  &:hover {
-    background-color: #f0e7e7;
-  }
+  background-color: #f0e7e7;
 `;
 
 const ChannelUserButton = styled.div`

--- a/frontend/src/components/Main/ContentsSection/ThreadSection.tsx
+++ b/frontend/src/components/Main/ContentsSection/ThreadSection.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useRef } from 'react';
+import React, { useContext, useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 import ChannelEntity from '../../../types/channel';
 import { CommentListInfo, CommentRequestBody } from '../../../types/comment';
@@ -115,6 +115,7 @@ type ThreadSectionProps = {
 function ThreadSection(props: ThreadSectionProps): JSX.Element {
   const { selectedMessageData, selectedChannel, socket } = useContext(MainStoreContext);
   const { setIsThreadOpen, channelInfo, commentList } = props;
+  const [channelName, setChannelName] = useState<string>('');
   const textDivRef = useRef<HTMLDivElement>(null);
 
   const sendComment = async (contents: string) => {
@@ -145,12 +146,16 @@ function ThreadSection(props: ThreadSectionProps): JSX.Element {
   const mainMessage = buildCommentElement(selectedMessageData, false);
   const CommentItemList = buildCommentItemList();
 
+  useEffect(() => {
+    if (channelInfo) setChannelName(channelInfo.name);
+  }, [selectedMessageData]);
+
   return (
     <Container>
       <ThreadSectionHeader>
         <ChannelName>
           <ThreadSpan>쓰레드</ThreadSpan>
-          <ChannelNameSpan># {channelInfo && channelInfo.name}</ChannelNameSpan>
+          <ChannelNameSpan># {channelName}</ChannelNameSpan>
         </ChannelName>
         <CloseIcon onClick={onClickCloseIcon} />
       </ThreadSectionHeader>


### PR DESCRIPTION
- ChannelList와 CamList의 기본 상태를 open 으로 변경
- Channel을 변경하여도 ThreadSection의 헤더가 변경되지 않도록 수정
- Channel이 부득이하게 삭제됐을 시 나오는 에러 페이지가 정상 출력되도록 수정
- MessageSection Header의 요소들이 최소 크기를 가지도록 수정
- ChannelName에 커서가 바뀌지 않도록 수정